### PR TITLE
use git shortlog and .mailmap to remove duplicates

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,1 @@
+Richard Hartmann <richih.mailinglist@gmail.com> <richih+github.com@richih.org>

--- a/tools/list_AUTHORS
+++ b/tools/list_AUTHORS
@@ -2,4 +2,4 @@
 
 echo 'Alphabetical list of everyone who ever committed to this repository
 '
-git log --all --format='%an <%ae>' | sort -u -k2
+git shortlog -se --all | cut -f1 --complement | sort -u -k2


### PR DESCRIPTION
When using the basic log command one of the authors shows up twice:

zsh» git log --all --format='%an <%ae>' | sort -u -k2
Vincent Demeester vincent@demeester.fr
Richard Hartmann <richih+github.com@richih.org>
Richard Hartmann richih.mailinglist@gmail.com
Dieter Plaetinck dieter@plaetinck.be
Corey Quinn corey@sequestered.net
Gernot Schulz post@gernot-schulz.com

If you instead use the git shortlog version with the .mailmap file you get:

zsh» git shortlog -se --all | cut -f1 --complement | sort -u -k2

Vincent Demeester vincent@demeester.fr
Richard Hartmann richih.mailinglist@gmail.com
Dieter Plaetinck dieter@plaetinck.be
Corey Quinn corey@sequestered.net
Gernot Schulz post@gernot-schulz.com

Alphabetical sorting on the second field (which, incidentally, may be a middle
name) is preserved.
