### PR TITLE
Use rm -f when removing a git repo.

### DIFF
--- a/vcsh
+++ b/vcsh
@@ -151,7 +151,7 @@ To continue, type 'Yes, do as I say'"
 	for file in $files; do
 		rm -f $file || info "could not delete '$file', continuing with deletion"
 	done
-	rm -r "$GIT_DIR" || error "could not delete '$GIT_DIR'"
+	rm -rf "$GIT_DIR" || error "could not delete '$GIT_DIR'"
 }
 
 enter() {


### PR DESCRIPTION
Git repos place the files as write-protected by default, so the
vcsh delete operation requires the user to typo 'y' repeatedly as the
repo is deleted. Using -f removes the repository properly.
