### PR TITLE
Anchor ignore lines

### DIFF
--- a/vcsh
+++ b/vcsh
@@ -256,7 +256,7 @@ write_gitignore() {
 		done;
 	done | sort -u)
 	tempfile=$(mktemp) || fatal "could not create tempfile" 51
-	echo '/*' > "$tempfile" || fatal "could not write to '$tempfile'" 57
+	echo '*' > "$tempfile" || fatal "could not write to '$tempfile'" 57
 	for gitignore in $gitignores; do
 		echo "$gitignore" | sed 's@^@!/@' >> "$tempfile" || fatal "could not write to '$tempfile'" 57
 		if [ x$VCSH_GITIGNORE = x'recursive' ] && [ -d "$gitignore" ]; then


### PR DESCRIPTION
The lines written to the gitignore file by write-gitignore were not
anchored. This means that a line like

  !.zsh

might cause not only ~/.zsh to be ignored, but also ~/TODO/.zsh, which
is potentially a problem.

This patch simply prepends a '/' to each entry in the gitignore file,
thereby anchoring the entry to the repository root.

Signed-off-by: martin f. krafft madduck@madduck.net
