### PR TITLE
Anchor ignore lines

### DIFF
--- a/vcsh
+++ b/vcsh
@@ -258,9 +258,9 @@ write_gitignore() {
 	tempfile=$(mktemp) || fatal "could not create tempfile" 51
 	echo '*' > "$tempfile" || fatal "could not write to '$tempfile'" 57
 	for gitignore in $gitignores; do
-		echo "$gitignore" | sed 's/^/!/' >> "$tempfile" || fatal "could not write to '$tempfile'" 57
+		echo "$gitignore" | sed 's@^@!/@' >> "$tempfile" || fatal "could not write to '$tempfile'" 57
 		if [ x$VCSH_GITIGNORE = x'recursive' ] && [ -d "$gitignore" ]; then
-			{ echo "$gitignore/*" | sed 's/^/!/' >> "$tempfile" || fatal "could not write to '$tempfile'" 57; }
+			{ echo "$gitignore/*" | sed 's@^@!/@' >> "$tempfile" || fatal "could not write to '$tempfile'" 57; }
 		fi
 	done
 	if diff -N "$tempfile" "$VCSH_BASE/.gitignore.d/$VCSH_REPO_NAME" > /dev/null; then


### PR DESCRIPTION
The lines written to the gitignore file by write-gitignore were not
anchored. This means that a line like

  !.zsh

might cause not only ~/.zsh to be ignored, but also ~/TODO/.zsh, which
is potentially a problem.

This patch simply prepends a '/' to each entry in the gitignore file,
thereby anchoring the entry to the repository root.

Note that the initial '*' must not be anchored, else files in
subdirectories wouldn't be ignored.

Signed-off-by: martin f. krafft madduck@madduck.net
