### PR TITLE
Relative worktrees

### DIFF
--- a/vcsh
+++ b/vcsh
@@ -108,7 +108,7 @@ if [ -n "$VCSH_OPTION_CONFIG" ]; then
 fi
 [ -n "$VCSH_DEBUG" ]                  && set -vx
 
-[ -z "$VCSH_RUN_FIXUPS" ]             && VCSH_RUN_FIXUPS="rel_worktree"
+[ -z "$VCSH_RUN_FIXUPS" ]             && VCSH_RUN_FIXUPS= #"rel_worktree"
 
 # Read defaults
 [ -z "$VCSH_REPO_D" ]                 && VCSH_REPO_D="$XDG_CONFIG_HOME/vcsh/repo.d"


### PR DESCRIPTION
core.worktree will be set to a relative path, which has a well-defined behaviour. There is also functionality in place to migrate existing repositories as part of a more generic "fixup" infrastructure, but that is disabled for now.
