### PR TITLE
Run upgrade after rename, fixes RichiH/vcsh#54

### DIFF
--- a/vcsh
+++ b/vcsh
@@ -226,6 +226,7 @@ rename() {
 	git_dir_exists
 	[ -d "$GIT_DIR_NEW" ] && fatal "'$GIT_DIR_NEW' exists" 54
 	mv -f "$GIT_DIR" "$GIT_DIR_NEW" || fatal "Could not mv '$GIT_DIR' '$GIT_DIR_NEW'" 52
+	vcsh upgrade "$VCSH_REPO_NAME_NEW"
 
 }
 
@@ -324,7 +325,7 @@ elif [ "$1" = 'delete' ]           ||
 	export VCSH_COMMAND="$1"
 	export VCSH_REPO_NAME="$2"
 	export GIT_DIR="$VCSH_REPO_D/$VCSH_REPO_NAME.git"
-	[ "$VCSH_COMMAND" = 'rename' ]         && export GIT_DIR_NEW="$VCSH_REPO_D/$3.git"
+	[ "$VCSH_COMMAND" = 'rename' ] && export VCSH_REPO_NAME_NEW="$3" && export GIT_DIR_NEW="$VCSH_REPO_D/$3.git"
 	[ "$VCSH_COMMAND" = 'run' ] && shift 2
 	[ "$VCSH_COMMAND" = 'write-gitignore' ]
 elif [ "$1" = 'list' ] ||


### PR DESCRIPTION
This time I made changes in a separate branch. Please look and tell what you think.
The actual problem is that after running vcsh rename command the value of core.excludesfile in repo's config section does not change.
