### PR TITLE
Call unuse before post-clone hook

### DIFF
--- a/vcsh
+++ b/vcsh
@@ -150,6 +150,7 @@ clone() {
 		fatal "will stop after fetching and not try to merge!
   Once this situation has been resolved, run 'vcsh run $VCSH_REPO_NAME git pull' to finish cloning.\n" 17
 	git merge origin/master
+	unuse
 	hook post-clone
 }
 


### PR DESCRIPTION
Use case:
I manage vim bundles with NeoBundle, so NeoBundle repo should be separately delivered into ~/.vim/bundle folder.
I do not add this repo to my vim vcsh config, I just add post clone hook to do it for me:

`.config/vcsh/hooks-enabled/vim.post-clone`:

``` bash
#!/usr/bin/env bash

git clone git://github.com/Shougo/neobundle.vim ~/.vim/bundle/neobundle.vim
```

Without calling `unuse` before post-clone it fails. 
Maybe we really should add one more hook, like `post-clone-cleaned` or `post-clone-after`
And if you find a better name for `unuse` it would be great, because I'm terrible at naming things.

If you know how to solve this problem without post-clone hook, please let me know.
