### PR TITLE
Relative worktrees

### DIFF
--- a/vcsh
+++ b/vcsh
@@ -248,7 +248,6 @@ push() {
 }
 
 retire() {
-	unset GIT_WORK_TREE
 	unset VCSH_DIRECTORY
 }
 
@@ -289,7 +288,6 @@ upgrade() {
 
 use() {
 	git_dir_exists
-	export GIT_WORK_TREE="$(git rev-parse --show-toplevel)"
 	export VCSH_DIRECTORY="$VCSH_REPO_NAME"
 }
 


### PR DESCRIPTION
core.worktree can be set relatively to GIT_DIR, thereby preventing the hard-coding of the home directory path, which should make a vcsh setup more portable.

On the other hand, this means that the vcsh repo.d is now invariably linked to its position, relative to the base directory. Apply this patch only if you think it to be less likely that people change ~/.config/vcsh/repo.d to something else, than they would rsync/tar/mv a whole tree to a different $HOME.

Paths are resolved using Git itself, for maximum portability.

In any case, this patch gets rid of GIT_WORK_TREE completely, which makes the whole thing a bit more transparent, I find. If you want to keep GIT_WORK_TREE, use "git rev-parse --show-toplevel" to obtain the absolute path for each vcsh session.

In addition to making sure the new method works on new repositories, I checked that
- "old" repositories can be used with the new code just fine;
- upgrading works.
