### PR TITLE
vcsh: Create the local branch during clone

### DIFF
--- a/vcsh
+++ b/vcsh
@@ -157,7 +157,7 @@ clone() {
 		info "remote is empty, not merging anything"
 		exit
 	fi
-	git fetch
+	git fetch origin "$VCSH_BRANCH"
 	for object in $(git ls-tree -r origin/"$VCSH_BRANCH" | awk '{print $4}'); do
 		[ -e "$object" ] &&
 			error "'$object' exists." &&


### PR DESCRIPTION
This will create and checkout a local branch named after the upstream
branch. It will also gracefully behave for the default `master' branch
and consistently show the same message:

Switched to a new branch '$VCSH_BRANCH'
