### PR TITLE
Make ronn tool configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 PREFIX=/usr
+RONN ?= ronn
 
 self=vcsh
 manpages=$(self).1
@@ -20,7 +21,7 @@ install: all
 manpages: $(manpages)
 
 $(self).1: doc/$(self).1.ronn
-	ronn < doc/$(self).1.ronn > $(self).1
+	$(RONN) < doc/$(self).1.ronn > $(self).1 || rm $(self).1
 
 clean:
 	rm -rf $(self).1


### PR DESCRIPTION
On Macports one need to run ronn-1.9 instead of ronn. Therefore
make ronn tool configurable. one can now run

make RONN=ronn-1.9

to execute ronn-1.9 instead of the default ronn.

Signed-off-by: Gregor Jasny gjasny@googlemail.com
