### PR TITLE
Make Makefile more configurable (doc and zsh dirs)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
 PREFIX=/usr
+DOCDIR=$(PREFIX)/share/doc/$(self)
+ZSHDIR=$(PREFIX)/share/zsh/vendor-completions
 
 self=vcsh
 manpages=$(self).1
@@ -11,11 +13,11 @@ install: all
 	install -m 0755 $(self) $(DESTDIR)$(PREFIX)/bin
 	install -d $(DESTDIR)$(PREFIX)/share/man/man1
 	install -m 0644 $(manpages) $(DESTDIR)$(PREFIX)/share/man/man1
-	install -d $(DESTDIR)$(PREFIX)/share/doc/$(self)
-	install -m 0644 README.md $(DESTDIR)$(PREFIX)/share/doc/$(self)
-	install -m 0644 doc/hooks $(DESTDIR)$(PREFIX)/share/doc/$(self)
-	install -d $(DESTDIR)$(PREFIX)/share/zsh/vendor-completions
-	install -m 0644 _$(self) $(DESTDIR)$(PREFIX)/share/zsh/vendor-completions
+	install -d $(DESTDIR)$(DOCDIR)
+	install -m 0644 README.md $(DESTDIR)$(DOCDIR)
+	install -m 0644 doc/hooks $(DESTDIR)$(DOCDIR)
+	install -d $(DESTDIR)$(ZSHDIR)
+	install -m 0644 _$(self) $(DESTDIR)$(ZSHDIR)
 
 manpages: $(manpages)
 
@@ -28,16 +30,16 @@ clean:
 uninstall:
 	rm -rf $(DESTDIR)$(PREFIX)/bin/$(self)
 	rm -rf $(DESTDIR)$(PREFIX)/share/man/man1/$(self).1
-	rm -rf $(DESTDIR)$(PREFIX)/share/doc/$(self)
-	rm -rf $(DESTDIR)$(PREFIX)/share/zsh/vendor-completions/_$(self)
+	rm -rf $(DESTDIR)$(DOCDIR)
+	rm -rf $(DESTDIR)$(ZSHDIR)/_$(self)
 
 # Potentially harmful, used a non-standard option on purpose.
 # If PREFIX=/usr/local and that's empty...
 purge: uninstall
 	rmdir -p --ignore-fail-on-non-empty $(DESTDIR)$(PREFIX)/bin/
 	rmdir -p --ignore-fail-on-non-empty $(DESTDIR)$(PREFIX)/share/man/man1/
-	rmdir -p --ignore-fail-on-non-empty $(DESTDIR)$(PREFIX)/share/doc/
-	rmdir -p --ignore-fail-on-non-empty $(DESTDIR)$(PREFIX)/share/zsh/vendor-completions/
+	rmdir -p --ignore-fail-on-non-empty $(DESTDIR)$(shell dirname $(DOCDIR))
+	rmdir -p --ignore-fail-on-non-empty $(DESTDIR)$(ZSHDIR)
 
 test:
 	if which git > /dev/null ; then :; else echo "'git' not found, exiting..."; exit 1; fi


### PR DESCRIPTION
It's only a matter of time until vcsh lands in Fedora [1] but packaging it needed some changes in the Makefile. I have kept it to the bare minimum, that is to say a `docdir` and a `zshdir` even though standard macros such as `bindir` or `mandir` exist (but are less likely to vary between various distributions).

[1] https://bugzilla.redhat.com/show_bug.cgi?id=vcsh
