### PR TITLE
Fix missing blank repository name when cloning

### DIFF
--- a/vcsh
+++ b/vcsh
@@ -18,7 +18,8 @@
 basename() {
 	# Implemented in shell to avoid spawning another process
 	local file
-	file="${1##*/}"
+	file="${1%/}"
+	file="${file##*/}"
 	[ -z "$2" ] || file="${file%$2}"
 	echo "$file"
 }
@@ -419,6 +420,7 @@ if [ "$VCSH_COMMAND" = 'clone' ]; then
 	[ -z "$2" ] && fatal "$VCSH_COMMAND: please specify a remote" 1
 	GIT_REMOTE="$2"
 	[ -n "$3" ] && VCSH_REPO_NAME="$3" || VCSH_REPO_NAME=$(basename "$GIT_REMOTE" .git)
+	[ -z "$VCSH_REPO_NAME" ] && fatal "$VCSH_COMMAND: could not determine repository name" 1
 	export VCSH_REPO_NAME
 	export GIT_DIR="$VCSH_REPO_D/$VCSH_REPO_NAME.git"
 elif [ "$VCSH_COMMAND" = 'version' ]; then


### PR DESCRIPTION
If the repository path given to 'vcsh clone' contains a trailing slash (as introduced by tab completion, e.g.: file:///path/to/repo/), the resulting cloned directory will be '.git' and vcsh will not recognize the cloned repository by name. This change ensures that a trailing slash will be stripped and the repository name will be populated.

The previous faulty behavior is due to the custom implementation of the basename command first introduced in 794f0aac.

Compare the following output:

```
$ file=foo/bar/
$ echo "${file##*/}"

$ basename $file
bar
$ basename --version | head -1
basename (GNU coreutils) 8.21
```

The only trouble with this solution as opposed to the basename command, is it does not trim multiple trailing slashes (which the shell seems to have to no trouble with). Obviously a handy regex could fix this, but this would defeat the purpose of replacing basename in the first place (performance).
