### PR TITLE
Minor additions/changes that make makefile more flexible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,11 @@
+self=vcsh
+version=20131214
 PREFIX=/usr
 DOCDIR_PREFIX=$(PREFIX)/share/doc
-DOCDIR=$(DOCDIR_PREFIX)/$(self)
-ZSHDIR=$(PREFIX)/share/zsh/vendor-completions
+DOCDIR=$(DOCDIR_PREFIX)/$(self)-$(version)
+ZSHDIR=$(PREFIX)/share/zsh/site-functions
 RONN ?= ronn
 
-self=vcsh
 manpages=$(self).1
 all=test manpages
 


### PR DESCRIPTION
Hello, I'd like to propose these changes. I think renaming ZSHDIR from vendor-completion into site-functions makes it more generic and software packagers will not need to patch it. Same for the DOCDIR path, adding version next to the vcsh name makes it more flexible.