### PR TITLE
Agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,6 +423,27 @@ and `git commit`, use the vcsh wrapper (like above):
     vcsh foo commit
     vcsh foo push
 
+### Using vcsh in directories other than $HOME
+
+You can use `vcsh` in an agnostic manner by changing the `$VCSH_BASE`
+and `$XDG_CONFIG_HOME` variables to the desired git working directory
+and `vcsh` config directory respectively. These variables can be
+changed a hierarchy of config files documented in the manpage, the
+agnostic file being `./.config/vcsh/config`.
+
+If the current working directory has a `.config` folder with the necessary `vcsh`
+config file, it will be automatically sourced. You can execute `vcsh
+where` to print out the values of the above two variables.
+
+Setting this up for a local folder is easy, just run `vcsh
+setup`. This will create `./.config/vcsh/config` with `$VCSH_BASE` set
+to `$(pwd)` and `$XDG_CONFIG_HOME` set to `$(pwd)/.config`. Now, when
+`vcsh` is run in this folder, it will track files in the folder, and
+use the local `.config` folder for `mr` and `repos.d`.
+
+Please note that `vcsh` will default back to `$HOME` if run in a
+sub-directory. It must be run from the root folder you wish to track.
+
 ### Using vcsh without myrepos
 
 vcsh encourages you to use [myrepos][myrepos]. It helps you manage a large number of

--- a/doc/vcsh.1.ronn
+++ b/doc/vcsh.1.ronn
@@ -29,11 +29,15 @@ vcsh(1) - Version Control System for $HOME - multiple Git repositories in $HOME
 
 `vcsh` run <repo> <shell command>
 
+`vcsh` setup
+
 `vcsh` status [<repo>]
 
 `vcsh` upgrade <repo>
 
 `vcsh` version
+
+`vcsh` where
 
 `vcsh` which <substring>
 
@@ -130,6 +134,17 @@ an interactive user.
   This is needed to support mr and other scripts properly and of no concern to
   an interactive user.
 
+* setup:
+  Creates ./config/vcsh/config with <$VCSH_BASE> and
+  <$XDG_CONFIG_HOME> variables set to `$(dir)` and `$(dir)/.config`
+  respectively. Allows for agnostic `vcsh` use in folders that are not
+  <$HOME>. Can also be run in <$HOME> for basic initial setup without
+  cloning the template.
+
+  Please note that `vcsh` will only detect the configuration from the
+  local working directory, and so will default back to <$HOME> if run
+  in a sub-directory. Use `vcsh where` to verify the above settings.
+
 * status:
   Show statuses of all/one vcsh repositories.
 
@@ -138,6 +153,10 @@ an interactive user.
 
 * version:
   Print version information.
+
+* where:
+
+  Print base <$VCSH_BASE> and config <$XDG_CONFIG_HOME> variables.
 
 * which <substring>:
   Find <substring> in name of any tracked file.
@@ -164,6 +183,7 @@ ascending precedence, they are:
 * `VARIABLE=foo vcsh`
 * </etc/vcsh/config>
 * <$XDG_CONFIG_HOME/vcsh/config>
+* <./.config/vcsh/config>
 * `vcsh -c <file>`
 
 Please note that those files are sourced. Any and all commands will be

--- a/vcsh
+++ b/vcsh
@@ -118,6 +118,7 @@ help() {
    status [<repo>]      Show statuses of all/one vcsh repositories
    upgrade <repo>       Upgrade repository to currently recommended settings
    version              Print version information
+   where                Print base and config directories
    which <substring>    Find substring in name of any tracked file
    write-gitignore \\
    <repo>               Write .gitignore.d/<repo> via git ls-files
@@ -348,6 +349,11 @@ use() {
 	export VCSH_DIRECTORY="$VCSH_REPO_NAME"
 }
 
+where() {
+	echo "\$VCSH_BASE is $VCSH_BASE"
+	echo "\$XDG_CONFIG_HOME is $XDG_CONFIG_HOME"
+}
+
 which() {
 	for VCSH_REPO_NAME in $(list); do
 		for VCSH_FILE in $(get_files); do
@@ -423,7 +429,8 @@ case "$VCSH_COMMAND" in
 	statu|stat|sta|st) VCSH_COMMAND=status;;
 	upgrad|upgra|upgr|up) VCSH_COMMAND=upgrade;;
 	versio|versi|vers|ver|ve) VCSH_COMMAND=version;;
-	which|whi|wh) VCSH_COMMAND=which;;
+	where|whe) VCSH_COMMAND=where;;
+	which|whi) VCSH_COMMAND=which;;
 	write|writ|wri|wr) VCSH_COMMAND=write-gitignore;;
 esac    
 
@@ -462,7 +469,8 @@ elif [ "$VCSH_COMMAND" = 'commit' ] ||
      [ "$VCSH_COMMAND" = 'list' ] ||
      [ "$VCSH_COMMAND" = 'list-tracked' ] ||
      [ "$VCSH_COMMAND" = 'pull' ] ||
-     [ "$VCSH_COMMAND" = 'push' ]; then
+     [ "$VCSH_COMMAND" = 'push' ] ||
+     [ "$VCSH_COMMAND" = 'where' ]; then
 	:
 elif [ "$VCSH_COMMAND" = 'status' ]; then
 	export VCSH_REPO_NAME="$2"

--- a/vcsh
+++ b/vcsh
@@ -397,7 +397,7 @@ write_gitignore() {
 		fatal "could not move '$tempfile' to '$VCSH_BASE/.gitignore.d/$VCSH_REPO_NAME'" 53
 }
 
-debug `git version`
+debug $(git version)
 
 if [ ! "x$VCSH_GITIGNORE" = 'xexact' ] && [ ! "x$VCSH_GITIGNORE" = 'xnone' ] && [ ! "x$VCSH_GITIGNORE" = 'xrecursive' ]; then
 	fatal "'\$VCSH_GITIGNORE' must equal 'exact', 'none', or 'recursive'" 1

--- a/vcsh
+++ b/vcsh
@@ -62,6 +62,7 @@ source_all() {
 # Read configuration files if there are any
 [ -r "/etc/vcsh/config" ]             && . "/etc/vcsh/config"
 [ -r "$XDG_CONFIG_HOME/vcsh/config" ] && . "$XDG_CONFIG_HOME/vcsh/config"
+[ -r ".config/vcsh/config" ]          && . ".config/vcsh/config"
 if [ -n "$VCSH_OPTION_CONFIG" ]; then
 	# Source $VCSH_OPTION_CONFIG if it can be read and is in $PWD of $PATH
 	if [ -r "$VCSH_OPTION_CONFIG" ]; then

--- a/vcsh
+++ b/vcsh
@@ -115,6 +115,7 @@ help() {
           <newname>     Rename repository
    run <repo> \\
        <command>        Use this repository
+   setup                Create ./.config/vcsh/config for local vcsh use
    status [<repo>]      Show statuses of all/one vcsh repositories
    upgrade <repo>       Upgrade repository to currently recommended settings
    version              Print version information
@@ -304,6 +305,14 @@ run() {
 	hook post-run
 }
 
+setup() {
+	mkdir -p .config/vcsh
+	echo "export VCSH_BASE=\"$(pwd)\"" >> .config/vcsh/config
+	echo "export XDG_CONFIG_HOME=\"$(pwd)/.config\"" >> .config/vcsh/config
+	echo "$SELF $VCSH_COMMAND: $SELF has been initialized in \"$(pwd)/.config\""
+	echo "$SELF will now track files locally if run from this directory"
+}
+
 status() {
 	if [ ! "x$VCSH_REPO_NAME" = "x" ]; then
 		export GIT_DIR="$VCSH_REPO_D/$VCSH_REPO_NAME.git"
@@ -426,6 +435,7 @@ case "$VCSH_COMMAND" in
 	pus) VCSH_COMMAND=push;;
 	renam|rena|ren|re) VCSH_COMMAND=rename;;
 	ru) VCSH_COMMAND=run;;
+	setup|setu|set|se) VCSH_COMMAND=setup;;
 	statu|stat|sta|st) VCSH_COMMAND=status;;
 	upgrad|upgra|upgr|up) VCSH_COMMAND=upgrade;;
 	versio|versi|vers|ver|ve) VCSH_COMMAND=version;;
@@ -445,6 +455,8 @@ elif [ "$VCSH_COMMAND" = 'version' ]; then
 	echo "$SELF $VERSION"
 	git version
 	exit
+elif [ "$VCSH_COMMAND" = 'setup' ]; then
+	[ -r "./.config/vcsh/config" ] && fatal "$VCSH_COMMAND: .config already exists!"
 elif [ "$VCSH_COMMAND" = 'which' ]; then
 	[ -z "$2" ] && fatal "$VCSH_COMMAND: please specify a filename" 1
 	[ -n "$3" ] && fatal "$VCSH_COMMAND: too many parameters" 1

--- a/vcsh
+++ b/vcsh
@@ -54,20 +54,16 @@ source_all() {
 	esac;
 }
 
-find_dir_upwards() {
-    op="$1"
-    dir="$2"
-    (
-	while [ `pwd` != / ] ; do
-	    if [ $op "$dir" ] ; then
-		pwd
-		return
-	    fi
-	    cd ..
-	done
-    )
+test_dir_upwards() {
+	# Recurses upwards testing [ $1 $2 ], returning pwd when true
+	(while [ $(pwd) != / ]; do
+		if [ "$1" "$2" ]; then
+	    	pwd
+	    	return
+		fi
+		cd ..
+	done)
 }
-
 
 # Read configuration and set defaults if anything's not set
 [ -n "$VCSH_DEBUG" ]                  && set -vx
@@ -78,9 +74,9 @@ find_dir_upwards() {
 [ -r "$XDG_CONFIG_HOME/vcsh/config" ] && . "$XDG_CONFIG_HOME/vcsh/config"
 [ -r ".config/vcsh/config" ]          && . ".config/vcsh/config"
 
-# Look up the directory tree for the appropriate flag
-configdir=`find_dir_upwards -r .config/vcsh/config`
-[ -n "$configdir" ] && . "$configdir/.config/vcsh/config"
+# Recursively look up the directory tree for configuration file
+configdir=$(test_dir_upwards -r .config/vcsh/config)
+[ -n "$configdir" ]                   && . "$configdir/.config/vcsh/config"
 
 if [ -n "$VCSH_OPTION_CONFIG" ]; then
 	# Source $VCSH_OPTION_CONFIG if it can be read and is in $PWD of $PATH


### PR DESCRIPTION
As per PR #114, this adds the `vcsh setup` and `vcsh where` commands, with necessary documentation. It also enables the sourcing of `./.config/vcsh/config`, which `vcsh setup` will automatically create with the `$VCSH_BASE` and `$XDG_CONFIG_HOME` variables set to `$(pwd)` and `$(pwd)/.config` respectively, thus enable "agnostic" use of `vcsh` from the folders with the a `./.config/vcsh/config` file.

It's a work in progress, and probably needs more testing, but I think it's a good way to go about doing this.
