### PR TITLE
Made delete() handle submodules correctly

### DIFF
--- a/vcsh
+++ b/vcsh
@@ -196,7 +196,7 @@ To continue, type 'Yes, do as I say'"
 	read answer
 	[ "x$answer" = 'xYes, do as I say' ] || exit 16
 	for file in $files; do
-		rm -f $file || info "could not delete '$file', continuing with deletion"
+		rm -rf $file || info "could not delete '$file', continuing with deletion"
 	done
 	rm -rf "$GIT_DIR" || error "could not delete '$GIT_DIR'"
 }


### PR DESCRIPTION
Previously delete() did not use the `-r` flag when invoking rm, which
meant that it could not remove any submodules in a repo (since these
appear as directories in `git ls-files`). This patch adds that flag to
fix this.
