### PR TITLE
vcsh: list_untracked(): remove --nocheck-order

### DIFF
--- a/vcsh
+++ b/vcsh
@@ -312,7 +312,7 @@ list_untracked_helper() {
 		cp $temp_file_others $temp_file_untracked || fatal 'Could not copy temp file'
 	fi
 	cp $temp_file_untracked $temp_file_untracked_copy || fatal 'Could not copy temp file'
-	comm -12 --nocheck-order $temp_file_others $temp_file_untracked_copy > $temp_file_untracked
+	comm -12 $temp_file_others $temp_file_untracked_copy > $temp_file_untracked
 }
 
 pull() {


### PR DESCRIPTION
`--nocheck-order` is only supported by GNU `comm`, but it isn't
necessary anyway because we sort the inputs first.