### PR TITLE
keep gitignore & gitattributes on upgrade/rename

### DIFF
--- a/vcsh
+++ b/vcsh
@@ -410,10 +410,34 @@ upgrade() {
 	elif [ ! "x$VCSH_WORKTREE" = 'xrelative' ]; then
 		git config core.worktree "$VCSH_BASE"
 	fi
-	[ ! "x$VCSH_GITIGNORE" = 'xnone' ] && git config core.excludesfile ".gitignore.d/$VCSH_REPO_NAME"
-	[ ! "x$VCSH_GITATTRIBUTES" = 'xnone' ] && git config core.attributesfile ".gitattributes.d/$VCSH_REPO_NAME"
-	git config vcsh.vcsh 'true'
 	use
+	if [ ! "x$VCSH_GITIGNORE" = 'xnone' ]; then
+    old_gitignore_file=$(git config core.excludesfile)
+    git config core.excludesfile ".gitignore.d/$VCSH_REPO_NAME"
+    if [ ! -z "$old_gitignore_file" ] && [ ! "$old_gitignore_file" = ".gitignore.d/$VCSH_REPO_NAME" ] && [ ! "$old_gitignore_file" = "$VCSH_BASE/.gitignore.d/$VCSH_REPO_NAME" ]; then
+      if [ -e "$VCSH_BASE/$old_gitignore_file" ]; then
+        mv "$VCSH_BASE/$old_gitignore_file" "$VCSH_BASE/.gitignore.d/$VCSH_REPO_NAME" || error "could not rename .gitignore.d file from $old_gitignore_file"
+      elif [ -e "$old_gitignore_file" ]; then
+        mv $old_gitignore_file "$VCSH_BASE/.gitignore.d/$VCSH_REPO_NAME" || error "could not rename .gitignore.d file from $old_gitignore_file"
+      else
+        debug "no old gitignore file to rename"
+      fi
+    fi
+  fi
+  if [ ! "x$VCSH_GITATTRIBUTES" = 'xnone' ]; then
+    old_gitattributes_file=$(git config core.attributesfile)
+    git config core.attributesfile ".gitattributes.d/$VCSH_REPO_NAME"
+    if [ ! -z "$old_gitattributes_file" ] && [ ! "$old_gitattributes_file" = ".gitattributes.d/$VCSH_REPO_NAME" ] && [ ! "$old_gitattributes_file" = "$VCSH_BASE/.gitattributes.d/$VCSH_REPO_NAME" ]; then
+      if [ -e "$VCSH_BASE/$old_gitattributes_file" ]; then
+        mv "$VCSH_BASE/$old_gitattributes_file" "$VCSH_BASE/.gitattributes.d/$VCSH_REPO_NAME" || error "could not rename .gitattributes.d file from $old_gitattributes_file"
+      elif [ -e "$old_gitattributes_file" ]; then
+        mv $old_gitattributes_file "$VCSH_BASE/.gitattributes.d/$VCSH_REPO_NAME" || error "could not rename .gitattributes.d file from $old_gitattributes_file"
+      else
+        debug "no old gitattributes file to rename"
+      fi
+    fi
+  fi
+  git config vcsh.vcsh 'true'
 	[ -e "$VCSH_BASE/.gitignore.d/$VCSH_REPO_NAME" ] && git add -f "$VCSH_BASE/.gitignore.d/$VCSH_REPO_NAME"
 	[ -e "$VCSH_BASE/.gitattributes.d/$VCSH_REPO_NAME" ] && git add -f "$VCSH_BASE/.gitattributes.d/$VCSH_REPO_NAME"
 	hook post-upgrade
@@ -502,7 +526,7 @@ case $VCSH_COMMAND in
 	versio|versi|vers|ver|ve) VCSH_COMMAND=version;;
 	which|whi|wh) VCSH_COMMAND=which;;
 	write|writ|wri|wr) VCSH_COMMAND=write-gitignore;;
-esac    
+esac
 
 if [ x"$VCSH_COMMAND" = x'clone' ]; then
 	VCSH_BRANCH=


### PR DESCRIPTION
fixes #37, further to #54 -- I feel that the user expects to keep the .gitignore.d/foo and .gitattributes.d/foo files in effect when renaming repo foo to bar.  Currently `upgrade()` abandons the foo files and updates .git to point to bar files.

I've implemented renaming the files with [`mv`](http://pubs.opengroup.org/onlinepubs/9699919799//utilities/mv.html) in `upgrade()` so that even if `core.excludesfile` or `core.attributesfile` points elsewhere, they can be moved into the recommended location. 

`mv` will exit with an error instead of overwriting any file, and I've handled showing that to the user. 

I've only played with this a bit. Open for improvements.