### PR TITLE
Fixes test 100-init.d to work with locales other than English.

### DIFF
--- a/t/100-init.t
+++ b/t/100-init.t
@@ -14,7 +14,7 @@ my $output = `./vcsh status`;
 
 ok $output eq "", 'No repos set up yet.';
 
-$output = `./vcsh init test1`;
+$output = `LC_ALL=C ./vcsh init test1`;
 
 ok $output eq "Initialized empty shared Git repository in " . $ENV{'HOME'} . "/.config/vcsh/repo.d/test1.git/\n";
 


### PR DESCRIPTION
Test 100 compares the git output of the init command with a fixed string. Unfortunately, this will fail on systems which do not have their locale set to English. Explicitly setting all locales to C fixes tests on those systems.