### PR TITLE
t/100-init.t: Fix failure due to locale

### DIFF
--- a/t/100-init.t
+++ b/t/100-init.t
@@ -14,7 +14,7 @@ my $output = `./vcsh status`;
 
 ok $output eq "", 'No repos set up yet.';
 
-$output = `./vcsh init test1`;
+$output = `LC_ALL=C ./vcsh init test1`;
 
 ok $output eq "Initialized empty shared Git repository in " . $ENV{'HOME'} . "/.config/vcsh/repo.d/test1.git/\n";
 


### PR DESCRIPTION
When running the t/100-init.t test, it relies on an exact response from git. This fails, if the locale is different from the English default. This change fixes the bug by enforcing the English default locale for this test.