### PR TITLE
Makefile Portability and Safety Improvements

### DIFF
--- a/BSDmakefile
+++ b/BSDmakefile
@@ -1,0 +1,17 @@
+# BSD make-specific makefile, read only by BSD make and hence containing
+# BSD make-specific extensions (e.g., "ifeq (...)", "$(shell ...)").
+
+#FIXME: Conditionalize according to the "GNUmakefile" approach.
+
+# Default target, running all preparatory installation targets without actually
+# installing. This *MUST* be the first non-"."-prefixed target in this makefile.
+all: manpages test
+
+# Install vcsh and supplementary artifacts.
+install: all install-common
+# Install man pages and zsh completions.
+	install -m 0644 $(manpages) $(DESTDIR)$(MANDIR)/man1/
+	install -m 0644 $(zshcompletions) $(DESTDIR)$(ZSH_COMPLETIONS_DIR)/
+
+# Define all platform-agnostic variables and rules.
+.include "Makefile"

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,0 +1,71 @@
+# GNU make-specific makefile, read only by GNU make and hence containing
+# GNU make-specific extensions (e.g., "ifeq (...)", "$(shell ...)").
+
+# Define all platform-agnostic variables and rules.
+include Makefile
+
+# Absolute path of zsh's completions directory. Since Debian-based Linux distros
+# prefer a different directory to that of most platforms, test for the existence
+# of such directory before falling back to a platform-agnostic directory.
+ifneq ($(wildcard $(DESTDIR)$(ZSHDIR_PREFIX)/vendor-completions),)
+ZSH_COMPLETIONS_DIR:=$(ZSHDIR_PREFIX)/vendor-completions
+else ifneq ($(wildcard $(DESTDIR)$(ZSHDIR_PREFIX)/site-functions),)
+ZSH_COMPLETIONS_DIR:=$(ZSHDIR_PREFIX)/site-functions
+endif
+
+# List of targets to be run both when no target is specified and when the
+# "install" rule is run.
+all_targets:=
+
+# Non-empty only if the "manpages" target is listed in $(all).
+is_manpaging=
+
+# Non-empty only if the "test" target is listed in $(all).
+is_testing=
+
+# If Ronn is in the current $PATH, generate Ronn-based man pages by default.
+ifneq ($(shell command -v "$(RONN)" 2>/dev/null),)
+all_targets+= manpages
+is_manpaging:=true
+endif
+
+# If Git, Perl, and the Perl-based unit test runner "prove" are all in the
+# current $PATH and the requisite Perl modules are in the @INC module path, run
+# Perl-based unit tests by default.
+ifneq ($(shell command -v git 2>/dev/null),)
+ifneq ($(shell command -v perl 2>/dev/null),)
+ifneq ($(shell command -v prove 2>/dev/null),)
+ ifeq ($(shell perl -e 'use Test::Most; use Shell::Command;' 2>&1),)
+all_targets+= test
+is_testing:=true
+endif
+endif
+endif
+endif
+
+# Default target, running all preparatory installation targets without actually
+# installing. This *MUST* be the first non-"."-prefixed target in this makefile.
+all: $(all_targets)
+# Notify the user of skipped targets.
+ifeq ($(is_manpaging),)
+	@echo 'Skipping man page generation: "$(RONN)" not found.' 1>&2
+endif
+ifeq ($(is_testing),)
+	@echo 'Skipping unit tests: "git", "prove", and/or Perl modules "Test::Most" and "Shell::Command" not found.' 1>&2
+endif
+
+# Coerce the default target to be the prior target (rather than the first rule
+# defined by the makefile included above).
+.DEFAULT_GOAL:=all
+
+# Install vcsh and supplementary artifacts.
+install: all install-common
+# If the man page has been generated, install it during installation.
+ifneq ($(wildcard $(manpages)),)
+	install -m 0644 $(manpages) $(DESTDIR)$(MANDIR)/man1/
+endif
+
+# If zsh's completions directory exists, install ours there during installation.
+ifneq ($(ZSH_COMPLETIONS_DIR),)
+	install -m 0644 $(zshcompletions) $(DESTDIR)$(ZSH_COMPLETIONS_DIR)/
+endif

--- a/Makefile
+++ b/Makefile
@@ -1,48 +1,75 @@
-PREFIX?=/usr
-DOCDIR_PREFIX=$(PREFIX)/share/doc
-DOCDIR=$(DOCDIR_PREFIX)/$(self)
-ZSHDIR=$(PREFIX)/share/zsh/vendor-completions
-RONN ?= ronn
+# make-agnostic makefile, read by all make flavours including GNU make and hence
+# consisting of only POSIX make-compliant syntax.
+#
+# This makefile defines all variables and rules except those required by and
+# including the "all" and "install" rules, whose complexity necessitates
+# conditional logic inexpressible in POSIX make-compliant syntax.
 
 self=vcsh
+
+PREFIX?=/usr
+BINDIR=$(PREFIX)/bin
+DOCDIR_PREFIX=$(PREFIX)/share/doc
+DOCDIR=$(DOCDIR_PREFIX)/$(self)
+MANDIR=$(PREFIX)/share/man
+RONN ?= ronn
+
+# Basename of the man page to be generated.
 manpages=$(self).1
-all=test manpages
 
-all: $(all)
+# Basename of our zsh completions script.
+zshcompletions=_$(self)
 
-install: all
-	install -d $(DESTDIR)$(PREFIX)/bin
-	install -m 0755 $(self) $(DESTDIR)$(PREFIX)/bin
-	install -d $(DESTDIR)$(PREFIX)/share/man/man1
-	install -m 0644 $(manpages) $(DESTDIR)$(PREFIX)/share/man/man1
+# Absolute path of zsh's top-level data directory.
+ZSHDIR_PREFIX=$(PREFIX)/share/zsh
+
+# Absolute path of zsh's completions directory.
+ZSH_COMPLETIONS_DIR=$(ZSHDIR_PREFIX)/site-functions
+
+# List of abstract target names not corresponding to actual paths, preventing
+# conflicts with any such paths and improving efficiency in general.
+.PHONY: all clean install install-common manpages moo purge test uninstall
+
+# Install all paths *NOT* requiring conditional and hence non-POSIX logic.
+install-common:
+# Install the "vcsh" command.
+	install -m 0755 $(self) $(DESTDIR)$(BINDIR)/
+
+# Install documentation.
 	install -d $(DESTDIR)$(DOCDIR)
-	install -m 0644 README.md $(DESTDIR)$(DOCDIR)
-	install -m 0644 doc/hooks $(DESTDIR)$(DOCDIR)
-	install -d $(DESTDIR)$(ZSHDIR)
-	install -m 0644 _$(self) $(DESTDIR)$(ZSHDIR)
+	install -m 0644 README.md $(DESTDIR)$(DOCDIR)/
+	install -m 0644 doc/hooks $(DESTDIR)$(DOCDIR)/
 
+# Generate the manpage.
 manpages: $(manpages)
 
 $(self).1: doc/$(self).1.ronn
 	$(RONN) < doc/$(self).1.ronn > $(self).1 || rm $(self).1
 
+# Remove the generated manpage.
 clean:
 	rm -rf $(self).1
 
+# Remove all previously installed paths.
 uninstall:
-	rm -rf $(DESTDIR)$(PREFIX)/bin/$(self)
-	rm -rf $(DESTDIR)$(PREFIX)/share/man/man1/$(self).1
+	rm -rf $(DESTDIR)$(BINDIR)/$(self)
+	rm -rf $(DESTDIR)$(MANDIR)/man1/$(self).1
 	rm -rf $(DESTDIR)$(DOCDIR)
-	rm -rf $(DESTDIR)$(ZSHDIR)/_$(self)
+	rm -rf $(DESTDIR)$(ZSH_COMPLETIONS_DIR)/$(zshcompletions)
 
-# Potentially harmful, used a non-standard option on purpose.
-# If PREFIX=/usr/local and that's empty...
+# FIXME: The "--ignore-fail-on-non-empty" option is GNU-specific.
+
+# Remove all previously installed paths and all empty parent directories of
+# these paths. Since this is potentially harmful, this target has intentionally
+# been given a non-standard name. For example, if $(PREFIX) is "/usr/local" and
+# now empty due to uninstalling vcsh, this target would remove "/usr/local"!
 purge: uninstall
-	rmdir -p --ignore-fail-on-non-empty $(DESTDIR)$(PREFIX)/bin/
-	rmdir -p --ignore-fail-on-non-empty $(DESTDIR)$(PREFIX)/share/man/man1/
+	rmdir -p --ignore-fail-on-non-empty $(DESTDIR)$(BINDIR)
+	rmdir -p --ignore-fail-on-non-empty $(DESTDIR)$(MANDIR)/man1
 	rmdir -p --ignore-fail-on-non-empty $(DESTDIR)$(DOCDIR)
-	rmdir -p --ignore-fail-on-non-empty $(DESTDIR)$(ZSHDIR)
+	rmdir -p --ignore-fail-on-non-empty $(DESTDIR)$(ZSH_COMPLETIONS_DIR)
 
+# Run all unit tests if both git and Perl's prove are found.
 test:
 	@if which git   > /dev/null; then :    ; else echo "'git' not found, exiting..."         ; exit 1; fi
 	@if which prove > /dev/null; then prove; else echo "'prove' not found; not running tests";         fi


### PR DESCRIPTION
This pull request addresses a depressing cornucopia of pressing Makefile issues, fixing #152 (and probably more) and subsuming pull requests #100 and arguably #145 (and probably more).

For the good of all that is portable and safe, let's get to it.
## A Few Problems

The laundry list of dirty ills includes:
- Installation requires unit tests to be run, thus requiring a [full Perl installation](#152) complete with the `Test::Most` and `Shell::Command` modules **despite `vcsh` itself not requiring Perl**.
- Installation requires man pages to be generated, thus requiring [`ronn` and hence Ruby](#145) **despite `vcsh` itself not requiring Ruby**.
- Zsh completions are installed to the [Debian-specific directory](http://www.zsh.org/mla/workers/2013/msg00622.html) `$(PREFIX)/share/zsh/vendor-completions` **regardless of whether Zsh is even installed**.
- Standard directories (e.g., `$(PREFIX)/bin`) are unsafely created when not found. If `/usr/bin` no longer exists, **something is horribly wrong**. Silently creating that directory (probably without the correct ownership or permissions) and blithely stumbling on as if everything is [hunky dory](https://www.youtube.com/watch?v=YQTENuQYgjM) is _not_ the sane response.
- Standard directories are hardcoded rather than exposed to the user as overridable variables (e.g., `$(PREFIX)/bin` rather than `$(BINDIR)`), contravening [GNU makefile conventions](https://www.gnu.org/prep/standards/html_node/Directory-Variables.html) and complicating the quiet, desperate lives of downstream packagers.
- Abstract makefile targets (i.e., targets with no existing path of the same basename) are _not_ listed in the `.PHONY` pseudo-target. While this isn't currently a concern, it is a plausible [ticking time bomb](https://www.gnu.org/software/make/manual/html_node/Phony-Targets.html) should any path with the same basename as an existing target be added to the `vcsh` codebase. 
## A Few Solutions

Our laundry list of sanitary fixes includes:
- **Divorcing installation from unit test running and man page generation.** Unit tests remain runnable via `make test` and man pages generable via `make manpages`, but neither are required to install `vcsh` anymore. For sanity, any man pages that _have_ been generated will still be installed when `sudo make install` is run. That's nice.
- **Zsh completions are installed to the [platform-agnostic directory](http://zsh.sourceforge.net/releases.html)** `$(PREFIX)/share/zsh/site-functions` _only_ if that directory and hence Zsh is installed.
- **Installation halts with a fatal error if any standard directory does not already exist.** Specifically, all such directories are explicitly suffixed by `/` when passed to `install`.
- **Standard directories are exposed to the user as overridable variables** with conventional names (e.g., `$(BINDIR)`, `$(MANDIR)`). 
- **Abstract makefile targets are listed in the `.PHONY` pseudo-target.**

Also, all targets now have human-readable comments.

The gnomes have learned a new way to say, ["Hooray!"](https://www.youtube.com/watch?v=em4Yl8qIm9Q) :ghost: 
