### PR TITLE
Speed up `vcsh which` and allow substring matching again

### DIFF
--- a/vcsh
+++ b/vcsh
@@ -427,9 +427,7 @@ use() {
 which() {
 	[ -e "$VCSH_COMMAND_PARAMETER" ] || fatal "'$VCSH_COMMAND_PARAMETER' does not exist" 1
 	for VCSH_REPO_NAME in $(list); do
-		for VCSH_FILE in $(get_files); do
-			echo "$VCSH_FILE" | grep -q "$VCSH_COMMAND_PARAMETER" && echo "$VCSH_REPO_NAME: $VCSH_FILE"
-		done
+		get_files | grep -- "$VCSH_COMMAND_PARAMETER" | sed "s/^/$VCSH_REPO_NAME: /"
 	done | sort -u
 }
 

--- a/vcsh
+++ b/vcsh
@@ -425,10 +425,16 @@ use() {
 }
 
 which() {
-	[ -e "$VCSH_COMMAND_PARAMETER" ] || fatal "'$VCSH_COMMAND_PARAMETER' does not exist" 1
+	got_result=0
+	# Pipes are launched in a subshell, so we need to communicate using a file
+	tempfile="$(mktemp "${TMPDIR:-/tmp}/tmp.XXXXXXXXXX")" || fatal 'Could not create temp file'
 	for VCSH_REPO_NAME in $(list); do
-		get_files | grep -- "$VCSH_COMMAND_PARAMETER" | sed "s/^/$VCSH_REPO_NAME: /"
+		get_files | grep -- "$VCSH_COMMAND_PARAMETER" | sed "s/^/$VCSH_REPO_NAME: /" | grep .
+		[ $? -eq 0 ] && echo 1 > "$tempfile"
 	done | sort -u
+	[ -s "$tempfile" ] && got_result=1
+	rm -f "$tempfile" || error "Could not delete '$tempfile'"
+	[ "$got_result" -eq 0 ] && fatal "No matching files where found" 1
 }
 
 write_gitignore() {


### PR DESCRIPTION
Noticed that `which` was really slow, so I replaced the inner for-loop by a simple sed-replacement.
This PR also solves #168, albeit somewhat ugly:
 - `grep .` is called just to get a non-zero exit status when output is generated. This feels unnecessary, but `PIPESTATUS` is a bash/zsh-only feature and this is still orders of magnitudes faster than the loop
 - to get the exit status outside of the outer loop, I actually had to use a tempfile, because pipes spawn a subshell and cannot modify variables 