### PR TITLE
Omit refspec during git fetch

### DIFF
--- a/vcsh
+++ b/vcsh
@@ -159,7 +159,7 @@ clone() {
   You should add files to your new repository."
 		exit
 	fi
-	git fetch origin "$VCSH_BRANCH"
+	git fetch origin
 	hook pre-merge
 	git ls-tree -r --name-only origin/"$VCSH_BRANCH" | (while read object; do
 		[ -e "$object" ] &&


### PR DESCRIPTION
Git 1.8 fails to retrieve `refs/remotes/origin/master` when specifying a
branch. Newer versions of Git don't seem to have this problem.

Below are three logs of git commands. The first shows the current problem the occurs with git 1.8. Note that the `refs/remotes/origin/master` is not retrieved during the fetch when the "master" branch is specified.

The second log shows the same commands, but this time the merge is successful, when "master" is omitted.

The third log shows the commands still work in a newer version of git that normally would work with "master" specified.

I do realize that this will cause all branches to be fetched. But specifying "master" seems to break compatibility with git 1.8.

```
------------------------------------------------------------------
$ git --version
git version 1.8.2.1
$ git init
Initialized empty Git repository in /homst/tbyrne/tmp/.git/
$ git remote add origin git@github.com:RichiH/vcsh_mr_template.git
$ git checkout -b master
Switched to a new branch 'master'
$ git fetch origin master
remote: Counting objects: 21, done.
remote: Total 21 (delta 0), reused 0 (delta 0), pack-reused 21
Unpacking objects: 100% (21/21), done.
From github.com:RichiH/vcsh_mr_template
 * branch            master     -> FETCH_HEAD
$ git merge origin/master
fatal: origin/master - not something we can merge
$ tree .git/refs/
.git/refs/
|-- heads
`-- tags
------------------------------------------------------------------
$ git --version
git version 1.8.2.1
$ git init
Initialized empty Git repository in /home/tbyrne/tmp/.git/
$ git remote add origin git@github.com:RichiH/vcsh_mr_template.git
$ git checkout -b master
Switched to a new branch 'master'
$ git fetch origin
remote: Counting objects: 21, done.
remote: Total 21 (delta 0), reused 0 (delta 0), pack-reused 21
Unpacking objects: 100% (21/21), done.
From github.com:RichiH/vcsh_mr_template
 * [new branch]      master     -> origin/master
$ tree .git/refs
.git/refs
|-- heads
|-- remotes
|   `-- origin
|       `-- master
`-- tags

$ git merge origin/master
$
------------------------------------------------------------------
$ git --version
git version 2.3.2 (Apple Git-55)
$ git init
Initialized empty Git repository in /Users/tbyrne/tmp/.git/
$ git remote add origin git@github.com:RichiH/vcsh_mr_template.git
$ git checkout -b master
Switched to a new branch 'master'
$ git fetch origin master
remote: Counting objects: 21, done.
remote: Total 21 (delta 0), reused 0 (delta 0), pack-reused 21
Unpacking objects: 100% (21/21), done.
From github.com:RichiH/vcsh_mr_template
 * branch            master     -> FETCH_HEAD
 * [new branch]      master     -> origin/master
$ tree .git/refs/
.git/refs/
├── heads
├── remotes
│   └── origin
│       └── master
└── tags

$ git merge origin/master
$
------------------------------------------------------------------
```