### PR TITLE
remove test from install dep, clarify README/INSTALL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ all=test manpages
 
 all: $(all)
 
-install: all
+install: manpages
 	install -d $(DESTDIR)$(PREFIX)/bin
 	install -m 0755 $(self) $(DESTDIR)$(PREFIX)/bin
 	install -d $(DESTDIR)$(PREFIX)/share/man/man1

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ vcsh - Version Control System for $HOME - multiple Git repositories in $HOME
 
 1. [30 Second How-to](#30-second-how-to)
 2. [Introduction](#introduction)
-3. [Contact](#contact)
+3. [Installation](#installation)
+4. [Contact](#contact)
 
 
 # 30 Second How-to
@@ -47,12 +48,6 @@ For example, you may not need to have your `mplayer` configuration on a server
 or available to root and you may want to maintain different configuration for
 `ssh` on your personal and your work machines.
 
-A lot of modern UNIX-based systems offer packages for `vcsh`. In case yours
-does not, read [INSTALL.md](doc/INSTALL.md) for install instructions or
-[PACKAGING.md](doc/PACKAGING.md) to create a package yourself. If you do end
-up packaging `vcsh` please let us know so we can give you your own packaging
-branch in the upstream repository.
-
 ## Talks
 
 Some people found it useful to look at slides and videos explaining how `vcsh`
@@ -60,6 +55,13 @@ works instead of working through the docs.
 All slides, videos, and further information can be found
 [on the author's talk page][talks].
 
+# Installation
+
+A lot of modern UNIX-based systems offer packages for `vcsh`. In case yours
+does not, read [INSTALL.md](doc/INSTALL.md) for install instructions or
+[PACKAGING.md](doc/PACKAGING.md) to create a package yourself. If you do end
+up packaging `vcsh` please let us know so we can give you your own packaging
+branch in the upstream repository.
 
 # Contact
 

--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -44,7 +44,18 @@ To clean up the generated manpage, run
 
 	make clean
 
-and if you are bored, I suggest
+To run the test suite, run
+
+    make test
+
+To run the test suite, you will need `perl`,
+and the modules `Test::Most` and `Shell::Command`.
+
+To install the perl modules, run
+
+    cpan install 'Test::Most' 'Shell::Command'.
+
+If you are bored, I suggest
 
 	make moo
 


### PR DESCRIPTION
`make install` fails in master without a few perl modules; I have fixed this and put installation in the README TOC
