### PR TITLE
Fix write_gitignore for git version >= 2.7

### DIFF
--- a/vcsh
+++ b/vcsh
@@ -476,14 +476,21 @@ write_gitignore() {
 
 	use
 	cd "$VCSH_BASE" || fatal "could not enter '$VCSH_BASE'" 11
+	local GIT_VERSION=$(git --version)
+	local GIT_VERSION_MAJOR=$(echo $GIT_VERSION | sed -n 's/.* \([0-9]\)\..*/\1/p')
+	local GIT_VERSION_MINOR=$(echo $GIT_VERSION | sed -n 's/.* \([0-9]\)\.\([0-9]\)\..*/\2/p')
 	OLDIFS=$IFS
 	IFS=$(printf '\n\t')
 	gitignores=$(for file in $(git ls-files); do
-		while true; do
-			echo "$file"; new=${file%/*}
-			[ x"$file" = x"$new" ] && break
-			file=$new
-		done;
+		if [ $GIT_VERSION_MAJOR -ge 2 -a $GIT_VERSION_MINOR -ge 7 ]; then
+			echo "$file";
+		else
+			while true; do
+				echo "$file"; new=${file%/*}
+				[ x"$file" = x"$new" ] && break
+				file=$new
+			done;
+		fi
 	done | sort -u)
 
 	# Contrary to GNU mktemp, mktemp on BSD/OSX requires a template for temp files


### PR DESCRIPTION
As of git version 2.7 it is no longer necessary to include parent
directories in the list of files not to be ignored.

This fixes #195.