### PR TITLE
Fix git version parsing when there are spaces

### DIFF
--- a/vcsh
+++ b/vcsh
@@ -476,7 +476,7 @@ write_gitignore() {
 
 	use
 	cd "$VCSH_BASE" || fatal "could not enter '$VCSH_BASE'" 11
-	local GIT_VERSION=$(git --version)
+	local GIT_VERSION="$(git --version)"
 	local GIT_VERSION_MAJOR=$(echo $GIT_VERSION | sed -n 's/.* \([0-9]\)\..*/\1/p')
 	local GIT_VERSION_MINOR=$(echo $GIT_VERSION | sed -n 's/.* \([0-9]\)\.\([0-9]\)\..*/\2/p')
 	OLDIFS=$IFS


### PR DESCRIPTION
On my machine, before this patch:
```
> git --version
git version 2.8.0rc3
> vcsh write-gitignore config-mr
/home/me/usr/bin/vcsh: 479: local: 2.8.0.rc3: bad variable name
```

