### PR TITLE
Use git read-tree (dry run) to detect conflicts

### DIFF
--- a/vcsh
+++ b/vcsh
@@ -169,13 +169,8 @@ clone() {
 		git fetch origin
 	fi
 	hook pre-merge
-	git ls-tree -r --name-only origin/"$VCSH_BRANCH" | (while read object; do
-		[ -e "$object" ] &&
-			error "'$object' exists." &&
-			VCSH_CONFLICT=1
-	done
-	[ x"$VCSH_CONFLICT" = x'1' ]) &&
-		fatal "will stop after fetching and not try to merge!
+	git read-tree -n -mu origin/"$VCSH_BRANCH" \
+		|| fatal "will stop after fetching and not try to merge!
   Once this situation has been resolved, run 'vcsh $VCSH_REPO_NAME pull' to finish cloning." 17
 	git -c merge.ff=true merge origin/"$VCSH_BRANCH"
 	hook post-merge


### PR DESCRIPTION
ls-tree does not account for sparse checkout settings and therefore
reports spurious conflicts if an existing file in the worktree conflicts
with a file in the repository which is not even being checked out. On the
other hand, read-tree takes care of sparse checkout settings.
