### PR TITLE
Fail the command if a hook script fails

### DIFF
--- a/vcsh
+++ b/vcsh
@@ -248,11 +248,17 @@ git_dir_exists() {
 	[ -d "$GIT_DIR" ] || fatal "no repository found for '$VCSH_REPO_NAME'" 12
 }
 
+# $1: message
+die () {
+  >&2 echo -e $1
+  exit 1
+}
+
 hook() {
 	for hook in "$VCSH_HOOK_D/$1"* "$VCSH_HOOK_D/$VCSH_REPO_NAME.$1"*; do
 		[ -x "$hook" ] || continue
 		verbose "executing '$hook'"
-		"$hook"
+		"$hook" || die "Hook [$hook] failed"
 	done
 }
 


### PR DESCRIPTION
Currently vcsh commands succeed even if a hook script fails. This is not
the right behavior in my opinion. The user should know when a hook fails
rather than silently continuing even though it may not make sense.
