### PR TITLE
Fix sed expression that parses GIT_VERSION_MINOR

### DIFF
--- a/vcsh
+++ b/vcsh
@@ -478,7 +478,7 @@ write_gitignore() {
 	cd "$VCSH_BASE" || fatal "could not enter '$VCSH_BASE'" 11
 	local GIT_VERSION="$(git --version)"
 	local GIT_VERSION_MAJOR=$(echo $GIT_VERSION | sed -n 's/.* \([0-9]\)\..*/\1/p')
-	local GIT_VERSION_MINOR=$(echo $GIT_VERSION | sed -n 's/.* \([0-9]\)\.\([0-9]\)\..*/\2/p')
+	local GIT_VERSION_MINOR=$(echo $GIT_VERSION | sed -n 's/.* \([0-9]\)\.\([0-9][0-9]*\)\..*/\2/p')
 	OLDIFS=$IFS
 	IFS=$(printf '\n\t')
 	gitignores=$(for file in $(git ls-files); do


### PR DESCRIPTION
Deal with 2-digit version numbers, as in "git version 2.13.1".