### PR TITLE
completion: Set the context correctly in 'foreach'.

### DIFF
--- a/_vcsh
+++ b/_vcsh
@@ -24,7 +24,7 @@ function _vcsh-enter () {
 }
 
 function _vcsh-foreach () {
-	_dispatch git git
+	_dispatch vcsh-foreach git
 }
 
 function _vcsh-help () {
@@ -135,6 +135,7 @@ function _vcsh () {
 			if ! (( ${+functions[_vcsh-$vcshcommand]} )); then
 				# There is no handler function, so this is probably the name
 				# of a repository. Act accordingly.
+				# FIXME: this may want to use '_dispatch vcsh git'
 				_dispatch git git
 			else
 				curcontext="${curcontext%:*:*}:vcsh-${vcshcommand}:"


### PR DESCRIPTION
This patch changes the zstyle context from `:completion::complete:git:…` to `:completion::complete:vcsh-foreach:…` when completing at `vcsh foreach <TAB>`.

The rationale is that `_vcsh` shouldn't be looking for completions under the `*:git:*` namespace.  The command being run is vcsh, not git.

The second hunk will have a trivial conflict with #225.  They change adjacent lines, but they're semantically independent of each other.