### PR TITLE
Do not use shared Git repositories

### DIFF
--- a/t/100-init.t
+++ b/t/100-init.t
@@ -18,7 +18,7 @@ ok $output eq "", 'No repos set up yet.';
 
 $output = `./vcsh init test1`;
 
-ok $output eq "Initialized empty shared Git repository in " . $ENV{'HOME'} . "/.config/vcsh/repo.d/test1.git/\n";
+ok $output eq "Initialized empty Git repository in " . $ENV{'HOME'} . "/.config/vcsh/repo.d/test1.git/\n";
 
 $output = `./vcsh status`;
 

--- a/vcsh
+++ b/vcsh
@@ -22,6 +22,9 @@
 VERSION='1.20141026'
 SELF=$(basename $0)
 
+# Ensure all files created are accessible only to the current user.
+umask 0077
+
 fatal() {
 	echo "$SELF: fatal: $1" >&2
 	[ -z $2 ] && exit 1
@@ -261,7 +264,7 @@ init() {
 	[ ! -e "$GIT_DIR" ] || fatal "'$GIT_DIR' exists" 10
 	mkdir -p "$VCSH_BASE" || fatal "could not create '$VCSH_BASE'" 50
 	cd "$VCSH_BASE" || fatal "could not enter '$VCSH_BASE'" 11
-	git init --shared=0600
+	git init --shared=false
 	upgrade
 	hook post-init
 }


### PR DESCRIPTION
Shared repositories were created using `git init --shared=0600` with the intent
of keeping configuration data private. Git reports an error if "shared"
repositories are created with private permissions. (Due to an apparent bug, the
error was not reported before git-2.13.2.)

Instead of creating a shared repository, use `umask 0077` to make created files
accessible only to the current user. The umask setting is inherited by child
processes and respected by Git.