### PR TITLE
completion: Complete only external command for 'run'.

### DIFF
--- a/_vcsh
+++ b/_vcsh
@@ -63,10 +63,12 @@ function _vcsh-rename () {
 
 function _vcsh-run () {
 	(( CURRENT == 2 )) && __vcsh_repositories
-	if (( CURRENT >= 3 )); then
+	(( CURRENT == 3 )) && _command_names -e
+	if (( CURRENT >= 4 )); then
+		# see _precommand in zsh
 		words=( "${(@)words[3,-1]}" )
 		(( CURRENT -= 2 ))
-		_complete
+		_normal
 	fi
 }
 


### PR DESCRIPTION
The difference is easiest to see when the following style is in effect:
```
zstyle ':completion:*' group-name ''
```

This prevents aliases, functions, names of shell paramaeters, etc from being offered.