### PR TITLE
Fix version processing on BSD systems.

### DIFF
--- a/vcsh
+++ b/vcsh
@@ -166,7 +166,7 @@ clone() {
   You should add files to your new repository."
 		exit
 	fi
-	GIT_VERSION_MAJOR=$(git --version | sed -n 's/.* \([0-9]\+\)\..*/\1/p' )
+	GIT_VERSION_MAJOR=$(git --version | sed -E -n 's/.* ([0-9]+)\..*/\1/p' )
 	if [ 1 -lt "$GIT_VERSION_MAJOR" ];then
 		git fetch origin "$VCSH_BRANCH"
 	else
@@ -482,8 +482,8 @@ write_gitignore() {
 	use
 	cd "$VCSH_BASE" || fatal "could not enter '$VCSH_BASE'" 11
 	local GIT_VERSION="$(git --version)"
-	local GIT_VERSION_MAJOR=$(echo $GIT_VERSION | sed -n 's/.* \([0-9]\+\)\..*/\1/p')
-	local GIT_VERSION_MINOR=$(echo $GIT_VERSION | sed -n 's/.* \([0-9]\+\)\.\([0-9]\+\)\..*/\2/p')
+	local GIT_VERSION_MAJOR=$(echo $GIT_VERSION | sed -E -n 's/.* ([0-9]+)\..*/\1/p')
+	local GIT_VERSION_MINOR=$(echo $GIT_VERSION | sed -E -n 's/.* ([0-9]+)\.([0-9]+)\..*/\2/p')
 	OLDIFS=$IFS
 	IFS=$(printf '\n\t')
 	gitignores=$(for file in $(git ls-files); do


### PR DESCRIPTION
BSD systems ship with the original sed; lacking a host of GNU
extensions. However both GNU sed and POSIX sed support the -E flag
for extended regular expressions which are close to the change this
is replacing.

See the descriptions of extended REs in IEEE Std 1003.2 (aka POSIX.2)
or re_format(7) on BSD systems. What matters for this is that the
+ operator works and that it and the grouping operators no longer
need to be escaped.