### PR TITLE
Alias commit to ci as well.

### DIFF
--- a/vcsh
+++ b/vcsh
@@ -534,7 +534,7 @@ VCSH_COMMAND=$1; export VCSH_COMMAND
 
 case $VCSH_COMMAND in
 	clon|clo|cl) VCSH_COMMAND=clone;;
-	commi|comm|com|co) VCSH_COMMAND=commit;;
+	commi|comm|com|co|ci) VCSH_COMMAND=commit;;
 	delet|dele|del|de) VCSH_COMMAND=delete;;
 	ente|ent|en) VCSH_COMMAND=enter;;
 	hel|he) VCSH_COMMAND=help;;


### PR DESCRIPTION
Mercurial, subversion and a common git alias for commit is "ci".
The PR adds that alias. Note that all of those also alias checkout
as "co" so this current case statement is a bit confusing.  That
said it doesn't make a huge amount of sense to do vcsh checkout so
it's fine if this stays if people have it in muscle memory.