### PR TITLE
Enable vcsh ls-file to take an option '-p'

### DIFF
--- a/vcsh
+++ b/vcsh
@@ -110,7 +110,8 @@ help() {
    delete <repo>        Delete an existing repository
    enter <repo>         Enter repository; spawn new instance of \$SHELL
                         with \$GIT_DIR set.
-   foreach [<-g>]
+   foreach \\
+     [<-g>] [<-p>] \\
      <git command>      Execute a command for every repository
    help                 Display this help text
    init <repo>          Initialize a new repository
@@ -234,17 +235,20 @@ foreach() {
 	# We default to prefixing `git` to all commands passed to foreach, but
 	# allow running in general context with -g
 	command_prefix=git
-	while getopts "g" flag; do
+	command_suffix='cat'
+	while getopts "gp" flag; do
 		if [ x"$1" = x'-g' ]; then
 			unset command_prefix
+		fi
+		if [ x"$1" = x'-p' ]; then
+			command_suffix='sed "s/^/$VCSH_REPO_NAME: /"'
 		fi
 		shift 1
 	done
 	for VCSH_REPO_NAME in $(list); do
-		echo "$VCSH_REPO_NAME:"
 		GIT_DIR=$VCSH_REPO_D/$VCSH_REPO_NAME.git; export GIT_DIR
 		use
-		$command_prefix "$@"
+		$command_prefix "$@" | eval $command_suffix
 	done
 	hook post-foreach
 }


### PR DESCRIPTION
Enable vcsh ls-file to take an option '-p' to prefix all lines with repo name

cf: #247 