### PR TITLE
Don't try to push/pull from repos without remote

### DIFF
--- a/vcsh
+++ b/vcsh
@@ -276,6 +276,13 @@ list() {
 	done
 }
 
+list_has_remote() {
+	for VCSH_REPO_NAME in $(list); do
+		GIT_DIR=$VCSH_REPO_D/$VCSH_REPO_NAME.git; export GIT_DIR
+		git config remote.origin.url >/dev/null && echo "$VCSH_REPO_NAME"
+	done
+}
+
 get_files() {
 	GIT_DIR=$VCSH_REPO_D/$VCSH_REPO_NAME.git; export GIT_DIR
 	git ls-files --full-name
@@ -354,7 +361,7 @@ list_untracked_helper() {
 
 pull() {
 	hook pre-pull
-	for VCSH_REPO_NAME in $(list); do
+	for VCSH_REPO_NAME in $(list_has_remote); do
 		printf '%s: ' "$VCSH_REPO_NAME"
 		GIT_DIR=$VCSH_REPO_D/$VCSH_REPO_NAME.git; export GIT_DIR
 		use
@@ -367,7 +374,7 @@ pull() {
 
 push() {
 	hook pre-push
-	for VCSH_REPO_NAME in $(list); do
+	for VCSH_REPO_NAME in $(list_has_remote); do
 		printf '%s: ' "$VCSH_REPO_NAME"
 		GIT_DIR=$VCSH_REPO_D/$VCSH_REPO_NAME.git; export GIT_DIR
 		use

--- a/vcsh
+++ b/vcsh
@@ -279,7 +279,7 @@ list() {
 list_has_remote() {
 	for VCSH_REPO_NAME in $(list); do
 		GIT_DIR=$VCSH_REPO_D/$VCSH_REPO_NAME.git; export GIT_DIR
-		git config remote.origin.url >/dev/null && echo "$VCSH_REPO_NAME"
+		git config branch.$VCSH_BRANCH.remote > /dev/null && echo "$VCSH_REPO_NAME"
 	done
 }
 


### PR DESCRIPTION
I have some repos managed by vcsh that are local only (e.g. one for my ~/.ssh dir). When I run `vcsh push` or `vcsh pull` I get these annoying spam'y error messages from git that I need to set up tracking information, which is fine but unnecessary.

This PR changes that so vcsh only tries to pull/push repos that have a remote set.