### PR TITLE
Add an option for `push` and `pull` to run their subcommands in parallel

### DIFF
--- a/vcsh
+++ b/vcsh
@@ -120,8 +120,8 @@ help() {
    list-untracked \\
         [<-a>] [<-r>]
         [<repo>]        List all files not tracked by all or one repositories
-   pull                 Pull from all vcsh remotes
-   push                 Push to vcsh remotes
+   pull [-j]            Pull from all vcsh remotes
+   push [-j]            Push to vcsh remotes
    rename <repo> \\
           <newname>     Rename repository
    run <repo> \\
@@ -355,26 +355,46 @@ list_untracked_helper() {
 
 pull() {
 	hook pre-pull
+	PIDS=""
 	for VCSH_REPO_NAME in $(list); do
 		printf '%s: ' "$VCSH_REPO_NAME"
 		GIT_DIR=$VCSH_REPO_D/$VCSH_REPO_NAME.git; export GIT_DIR
 		use
-		git pull
-		VCSH_COMMAND_RETURN_CODE=$?
+		if [ -z "$VCSH_PARALLEL" ]; then
+			git pull
+			VCSH_COMMAND_RETURN_CODE=$?
+		else
+			git pull --quiet &
+			PIDS="$PIDS $!"
+			echo 'pulling ...'
+		fi
 		echo
+	done
+	for PID in $PIDS; do
+		wait "$PID"
 	done
 	hook post-pull
 }
 
 push() {
 	hook pre-push
+	PIDS=""
 	for VCSH_REPO_NAME in $(list); do
 		printf '%s: ' "$VCSH_REPO_NAME"
 		GIT_DIR=$VCSH_REPO_D/$VCSH_REPO_NAME.git; export GIT_DIR
 		use
-		git push
-		VCSH_COMMAND_RETURN_CODE=$?
+		if [ -z "$VCSH_PARALLEL" ]; then
+			git push
+			VCSH_COMMAND_RETURN_CODE=$?
+		else
+			git push --quiet &
+			PIDS="$PIDS $!"
+			echo 'pushing ...'
+		fi
 		echo
+	done
+	for PID in $PIDS; do
+		wait "$PID"
 	done
 	hook post-push
 }
@@ -604,10 +624,14 @@ elif [ x"$VCSH_COMMAND" = x'foreach' ]; then
 elif [ x"$VCSH_COMMAND" = x'commit' ] ||
      [ x"$VCSH_COMMAND" = x'list'   ] ||
      [ x"$VCSH_COMMAND" = x'list-tracked' ] ||
-     [ x"$VCSH_COMMAND" = x'list-untracked' ] ||
-     [ x"$VCSH_COMMAND" = x'pull'   ] ||
+     [ x"$VCSH_COMMAND" = x'list-untracked' ]; then
+ 	:
+elif [ x"$VCSH_COMMAND" = x'pull'   ] ||
      [ x"$VCSH_COMMAND" = x'push'   ]; then
-	:
+	if [ x"$2" = x'-j' ]; then
+		VCSH_PARALLEL=1; export VCSH_PARALLEL
+		shift
+	fi
 elif [ x"$VCSH_COMMAND" = x'status' ]; then
 	if [ x"$2" = x'--terse' ]; then
 		VCSH_STATUS_TERSE=1; export VCSH_STATUS_TERSE


### PR DESCRIPTION
I usually have 3-6 repos on each machine that are managed by vcsh. When running `vcsh push` or `vcsh pull` it will go through all of them one after the other, even when most of them have no changes. This is bothersome and makes vcsh feel unnecessarily slow.

I propose adding a `-j` option to `vcsh push` and `vcsh pull` which runs all of the git commands as background subprocesses in parallel. The option name is based on `make`'s `-j` option which does roughly the same, but smarter and with the option to set the number of processes.

I made it an option and don't default to it, because the way it's implemented right now we lose `git`'s standard output. Having all sub-processes run at once and output to stdout, we'd end up with a garbled mess, so I opted to add `--quiet` to the call to `git`.
One way to handle this would be to redirect the subprocess' output to temporary files and display them each once they finished. This could easily be done in the `wait` loop.