### PR TITLE
Recursively delete repository directories

### DIFF
--- a/vcsh
+++ b/vcsh
@@ -216,7 +216,7 @@ To continue, type 'Yes, do as I say'"
 	read answer
 	[ "x$answer" = 'xYes, do as I say' ] || exit 16
 	for file in $files; do
-		rm -f $file || info "could not delete '$file', continuing with deletion"
+		rm -rf $file || info "could not delete '$file', continuing with deletion"
 	done
 	rm -rf "$GIT_DIR" || error "could not delete '$GIT_DIR'"
 }


### PR DESCRIPTION
This change allows vcsh to delete directories when removing a repository.

This fixes the situation where deleting a repository with submodules leaves behind submodules.

If a good case can be made for why `-r` should be optional, I can either rewrite delete to accept a `-r` option or introduce a separate recursive delete routine to vcsh.