### PR TITLE
Fix typo in Config section

### DIFF
--- a/doc/vcsh.1.ronn
+++ b/doc/vcsh.1.ronn
@@ -220,7 +220,7 @@ Interesting knobs you can turn:
 
   Defaults to <exact>.
 
-* <$VCSH_VCSH_WORKTREE>:
+* <$VCSH_WORKTREE>:
   Can be <absolute>, or <relative>.
 
   <absolute> will set an absolute path; defaulting to <$HOME>.


### PR DESCRIPTION
Changed `$VCSH_VCSH_WORKTREE` to `$VCSH_WORKTREE`