### PR TITLE
Make clone() check GIT_REMOTE early

### DIFF
--- a/vcsh
+++ b/vcsh
@@ -149,6 +149,8 @@ info() {
 
 clone() {
 	hook pre-clone
+	# Check if remote is reachable. Abort early if there's a typo, TLS certificate problem, etc
+	git ls-remote "$GIT_REMOTE" 2> /dev/null || fatal "Can not reach '$GIT_REMOTE'"
 	init
 	git remote add origin "$GIT_REMOTE"
 	git checkout -b "$VCSH_BRANCH" || return $?


### PR DESCRIPTION
Closes #161
Closes #209

This very sensible proposed fix to a long standing issue never made it into the default branch and hence not into releases. I can't see any good reason not to do this, the slight overhead has to be worth it to avoid dirty repository states. Clone isn't a frequent enough operation to make the compromise.