### PR TITLE
Build standalone script edition in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,63 @@
+name: Build
+
+on: [push, pull_request]
+
+jobs:
+
+  standalone:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Fetch tags
+        run: |
+          git fetch --prune --tags ||:
+      - name: Configure standalone script
+        run: |
+          ./bootstrap.sh
+          ./configure --with-standalone --bindir=/
+          make DESTDIR=. install-exec
+          echo VERSION=$(cat .version) >> $GITHUB_ENV
+      - name: Post standalone script artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: standalone-deployment-${{ env.VERSION }}
+          path: vcsh-standalone.sh
+
+  source-dist:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Fetch tags
+        run: |
+          git fetch --prune --tags ||:
+      - name: Install build dependencies
+        run: |
+          sudo apt install -y ronn
+      - name: Install perl test dependencies
+        uses: perl-actions/install-with-cpanm@v1.1
+        with:
+          install: |
+            Shell::Command
+            Test::Most
+      - name: Configure
+        run: |
+          ./bootstrap.sh
+          ./configure
+      - name: Run tests
+        run: |
+          make check
+      - name: Build source package
+        run: |
+          make dist
+          echo VERSION=$(cat .version) >> $GITHUB_ENV
+      - name: Post build artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: vcsh-${{ env.VERSION }}
+          path: vcsh-${{ env.VERSION }}.zip

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,9 @@
 name: Lint
+
 on: [push, pull_request]
+
 jobs:
+
   editor-config:
     runs-on: ubuntu-latest
     steps:
@@ -8,6 +11,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Lint code style
         uses: editorconfig-checker/action-editorconfig-checker@v1.0.0
+
   shellcheck:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
               --disable-tests \
               --without-bash-completion-dir \
               --without-zsh-completion-dir \
-              --with-edition=standalone \
+              --with-deployment=standalone \
               COMM=comm GIT=git GREP=grep SED=sed SHELL=/bin/sh
       - name: Upload standalone script artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,13 +21,16 @@ jobs:
               --disable-tests \
               --without-bash-completion-dir \
               --without-zsh-completion-dir \
+              --program-suffix=-standalone.sh \
               --with-deployment=standalone \
+              --bindir=/ \
               COMM=comm GIT=git GREP=grep SED=sed SHELL=/bin/sh
+            make DESTDIR=. install-exec
       - name: Upload standalone script artifact
         uses: actions/upload-artifact@v2
         with:
           name: vcsh-standalone
-          path: vcsh
+          path: vcsh-standalone.sh
 
   ghrelase:
     runs-on: ubuntu-latest
@@ -59,9 +62,6 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: vcsh-standalone
-          path: standalone
-      - name: Rename standalone deployment script
-        run: mv standalone/vcsh vcsh-standalone.sh
       - name: Publish Release
         uses: softprops/action-gh-release@v1
         with:
@@ -69,6 +69,6 @@ jobs:
           files: |
             vcsh-${{ env.VERSION }}.zip
             vcsh-${{ env.VERSION }}.tar.xz
-            vcsh-standalone.sh
+            standalone/vcsh-standalone.sh
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,28 @@ on:
 
 jobs:
 
+  standalone:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Configure standalone script
+        run: |
+          echo "VERSION=${GITHUB_REF#refs/*/v}" >> $GITHUB_ENV
+          ./bootstrap.sh
+          ./configure \
+              --without-man-page \
+              --disable-tests \
+              --without-bash-completion-dir \
+              --without-zsh-completion-dir \
+              --with-edition=standalone \
+              COMM=comm GIT=git GREP=grep SED=sed SHELL=/bin/sh
+      - name: Upload standalone script artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: vcsh-standalone
+          path: vcsh
+
   ghrelase:
     runs-on: ubuntu-latest
     steps:
@@ -28,6 +50,13 @@ jobs:
         run: |
           make changelog-HEAD
           grep -F "* Release ${{ env.VERSION }}" changelog-HEAD
+      - name: Download standalone script artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: vcsh-standalone
+          path: standalone
+      - name: Rename standalone deployment script
+        run: mv standalone/vcsh vcsh-standalone.sh
       - name: Publish Release
         uses: softprops/action-gh-release@v1
         with:
@@ -35,5 +64,6 @@ jobs:
           files: |
             vcsh-${{ env.VERSION }}.zip
             vcsh-${{ env.VERSION }}.tar.xz
+            vcsh-standalone.sh
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,8 +7,40 @@ on:
 
 jobs:
 
-  standalone:
+  ghrelease:
     runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install build dependencies
+        run: |
+          sudo apt install -y ronn
+      - name: Configure
+        run: |
+          echo "VERSION=${GITHUB_REF#refs/*/v}" >> $GITHUB_ENV
+          echo "${GITHUB_REF#refs/*/v}" > .tarball-version
+          ./bootstrap.sh
+          ./configure
+      - name: Make sure changelog was updated
+        run: |
+          make changelog-HEAD
+          grep -F "* Release ${{ env.VERSION }}" changelog-HEAD
+      - name: Build source package
+        run: |
+          make dist
+      - name: Publish Release
+        uses: softprops/action-gh-release@v1
+        with:
+          body_path: changelog-HEAD
+          files: |
+            vcsh-${{ env.VERSION }}.zip
+            vcsh-${{ env.VERSION }}.tar.xz
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+  deploy-standalone:
+    runs-on: ubuntu-latest
+    needs: [ ghrelease ]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -18,49 +50,9 @@ jobs:
           ./bootstrap.sh
           ./configure --with-standalone --bindir=/
           make DESTDIR=. install-exec
-      - name: Upload standalone script artifact
-        uses: actions/upload-artifact@v2
+      - name: Add standalone deployment to release
+        uses: svenstaro/upload-release-action@v2
         with:
-          name: standalone-deployment
-          path: vcsh-standalone.sh
-
-  ghrelase:
-    runs-on: ubuntu-latest
-    needs: [ standalone ]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Install ronn
-        run: |
-          sudo apt update
-          sudo apt install -y ronn
-      - name: Configure
-        run: |
-          echo "VERSION=${GITHUB_REF#refs/*/v}" >> $GITHUB_ENV
-          echo "${GITHUB_REF#refs/*/v}" > .tarball-version
-          ./bootstrap.sh
-          ./configure
-      - name: Build source package
-        run: |
-          make dist
-      - name: Check source package behaviour
-        run: |
-          make distcheck
-      - name: Make sure changelog was updated
-        run: |
-          make changelog-HEAD
-          grep -F "* Release ${{ env.VERSION }}" changelog-HEAD
-      - name: Download standalone script artifact
-        uses: actions/download-artifact@v2
-        with:
-          name: standalone-deployment
-      - name: Publish Release
-        uses: softprops/action-gh-release@v1
-        with:
-          body_path: changelog-HEAD
-          files: |
-            vcsh-${{ env.VERSION }}.zip
-            vcsh-${{ env.VERSION }}.tar.xz
-            vcsh-standalone.sh
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
+          repo_token: ${{ github.token }}
+          file: vcsh-standalone.sh
+          tag: ${{ github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,20 +16,12 @@ jobs:
         run: |
           echo "VERSION=${GITHUB_REF#refs/*/v}" >> $GITHUB_ENV
           ./bootstrap.sh
-          ./configure \
-              --without-man-page \
-              --disable-tests \
-              --without-bash-completion-dir \
-              --without-zsh-completion-dir \
-              --program-suffix=-standalone.sh \
-              --with-deployment=standalone \
-              --bindir=/ \
-              COMM=comm GIT=git GREP=grep SED=sed SHELL=/bin/sh
-            make DESTDIR=. install-exec
+          ./configure --with-standalone --bindir=/
+          make DESTDIR=. install-exec
       - name: Upload standalone script artifact
         uses: actions/upload-artifact@v2
         with:
-          name: vcsh-standalone
+          name: standalone-deployment
           path: vcsh-standalone.sh
 
   ghrelase:
@@ -61,7 +53,7 @@ jobs:
       - name: Download standalone script artifact
         uses: actions/download-artifact@v2
         with:
-          name: vcsh-standalone
+          name: standalone-deployment
       - name: Publish Release
         uses: softprops/action-gh-release@v1
         with:
@@ -69,6 +61,6 @@ jobs:
           files: |
             vcsh-${{ env.VERSION }}.zip
             vcsh-${{ env.VERSION }}.tar.xz
-            standalone/vcsh-standalone.sh
+            vcsh-standalone.sh
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,7 @@ jobs:
 
   ghrelase:
     runs-on: ubuntu-latest
+    needs: [ standalone ]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
               --disable-tests \
               --without-bash-completion-dir \
               --without-zsh-completion-dir \
-              --with-edition=standalone \
+              --with-deployment=standalone \
               COMM=comm GIT=git GREP=grep SED=sed SHELL=/bin/sh
       - name: Post standalone script artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,20 +17,12 @@ jobs:
       - name: Configure standalone script
         run: |
           ./bootstrap.sh
-          ./configure
-            --without-man-page \
-            --disable-tests \
-            --without-bash-completion-dir \
-            --without-zsh-completion-dir \
-            --with-deployment=standalone \
-            --program-suffix=-standalone.sh \
-            --bindir=/ \
-            COMM=comm GIT=git GREP=grep SED=sed SHELL=/bin/sh
+          ./configure --with-standalone --bindir=/
           make DESTDIR=. install-exec
       - name: Post standalone script artifact
         uses: actions/upload-artifact@v2
         with:
-          name: vcsh-standalone
+          name: standalone-deployment
           path: vcsh-standalone.sh
 
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,35 @@
 name: Test
+
 on: [push, pull_request]
+
 jobs:
+
+  standalone:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Fetch tags
+        run: |
+          git fetch --prune --tags ||:
+      - name: Configure standalone script
+        run: |
+          ./bootstrap.sh
+          ./configure \
+              --without-man-page \
+              --disable-tests \
+              --without-bash-completion-dir \
+              --without-zsh-completion-dir \
+              --with-edition=standalone \
+              COMM=comm GIT=git GREP=grep SED=sed SHELL=/bin/sh
+      - name: Post standalone script artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: vcsh-standalone
+          path: vcsh
+
   test:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,18 +17,21 @@ jobs:
       - name: Configure standalone script
         run: |
           ./bootstrap.sh
-          ./configure \
-              --without-man-page \
-              --disable-tests \
-              --without-bash-completion-dir \
-              --without-zsh-completion-dir \
-              --with-deployment=standalone \
-              COMM=comm GIT=git GREP=grep SED=sed SHELL=/bin/sh
+          ./configure
+            --without-man-page \
+            --disable-tests \
+            --without-bash-completion-dir \
+            --without-zsh-completion-dir \
+            --with-deployment=standalone \
+            --program-suffix=-standalone.sh \
+            --bindir=/ \
+            COMM=comm GIT=git GREP=grep SED=sed SHELL=/bin/sh
+          make DESTDIR=. install-exec
       - name: Post standalone script artifact
         uses: actions/upload-artifact@v2
         with:
           name: vcsh-standalone
-          path: vcsh
+          path: vcsh-standalone.sh
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,27 +4,6 @@ on: [push, pull_request]
 
 jobs:
 
-  standalone:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Fetch tags
-        run: |
-          git fetch --prune --tags ||:
-      - name: Configure standalone script
-        run: |
-          ./bootstrap.sh
-          ./configure --with-standalone --bindir=/
-          make DESTDIR=. install-exec
-      - name: Post standalone script artifact
-        uses: actions/upload-artifact@v2
-        with:
-          name: standalone-deployment
-          path: vcsh-standalone.sh
-
   test:
     runs-on: ubuntu-latest
     steps:
@@ -35,9 +14,9 @@ jobs:
       - name: Fetch tags
         run: |
           git fetch --prune --tags ||:
-      - name: Install dependencies
+      - name: Install build dependencies
         run: |
-          sudo apt install ronn
+          sudo apt install -y ronn
       - name: Install perl test dependencies
         uses: perl-actions/install-with-cpanm@v1.1
         with:
@@ -51,12 +30,6 @@ jobs:
       - name: Run tests
         run: |
           make check
-      - name: Build source package
+      - name: Run full cycle packaging check
         run: |
-          make dist
-          echo VERSION=$(cat .version) >> $GITHUB_ENV
-      - name: Post build artifacts
-        uses: actions/upload-artifact@v2
-        with:
-          name: vcsh-${{ env.VERSION }}
-          path: vcsh-${{ env.VERSION }}.zip
+          make distcheck

--- a/changelog
+++ b/changelog
@@ -19,6 +19,8 @@ unreleased
 	* Allow use of specific path when running Git or any dependency
 	* Fail if hook scripts return failure codes
 	* Check GIT_REMOTE early on clone()
+	* Support renaming script as configuration option
+	* Setup standalone script build profile and attach directly to releases
 
 2021-04-05  Richard Hartmann <richih.mailinglist@gmail.com>
 

--- a/configure.ac
+++ b/configure.ac
@@ -18,12 +18,12 @@ AX_PROGVAR([comm])
 AX_PROGVAR([cmp])
 AX_PROGVAR([git])
 
-AC_ARG_WITH([edition],
-            AS_HELP_STRING([--with-edition],
-                           [Add edition string to version @<:@default=@:>@]),
+AC_ARG_WITH([deployment],
+            AS_HELP_STRING([--with-deployment],
+                           [Add deployment string to version @<:@default=@:>@]),
             [],
-            [with_edition=])
-AC_SUBST([EDITION], [${with_edition:+-$with_edition}])
+            [with_deployment=])
+AC_SUBST([DEPLOYMENT], [${with_deployment:+-$with_deployment}])
 
 AC_ARG_WITH([man-page],
             AS_HELP_STRING([--with-man-page],

--- a/configure.ac
+++ b/configure.ac
@@ -18,6 +18,13 @@ AX_PROGVAR([comm])
 AX_PROGVAR([cmp])
 AX_PROGVAR([git])
 
+AC_ARG_WITH([edition],
+            AS_HELP_STRING([--with-edition],
+                           [Add edition string to version @<:@default=@:>@]),
+            [],
+            [with_edition=])
+AC_SUBST([EDITION], [${with_edition:+-$with_edition}])
+
 AC_ARG_WITH([man-page],
             AS_HELP_STRING([--with-man-page],
                            [Generate man page @<:@default=yes@:>@]),

--- a/configure.ac
+++ b/configure.ac
@@ -10,6 +10,23 @@ AC_DEFUN([AX_PROGVAR], [
           test -n "$m4_toupper($1)" || AC_MSG_ERROR([m4_default($2,$1) is required])
           ])
 
+AC_ARG_WITH([standalone],
+            AS_HELP_STRING([--with-standalone],
+                           [Use configuration presets for a standalone script deployment @<:@default=no@:>@]),
+            [COMM=comm GIT=git GREP=grep SED=sed SHELL=/bin/sh
+             with_deployment=standalone
+             with_man_page=no
+             enable_tests=no
+             with_bash_completion_dir=no
+             with_zsh_completion_dir=no
+             program_suffix=-standalone.sh
+             # By this point program_suffix has already been processed so we have to redo what configure did
+             # Code copied from approx L2670-2671
+             program_transform_name="s&\$&$program_suffix&;$program_transform_name"
+             program_transform_name=`printf "%s\n" "$program_transform_name" | sed "$ac_script"`
+            ],
+            [])
+
 AC_PROG_AWK
 AC_PROG_GREP
 AC_PROG_SED

--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -2,6 +2,7 @@
 
 Many distributions have packages ready to go.
 If yours doesn't, you can install [from source](#installing-from-source).
+VCSH can also be deployed as a [standalone script](#standalone-script).
 If you package VCSH for a distro please let us know.
 
 ## Arch Linux
@@ -123,5 +124,30 @@ $ make DESTDIR="$HOME" install-exec
 ```
 
 This will install to `~/bin/vcsh`; add `~/bin` to your path to use.
+
+# Standalone Script
+
+A special variant of VCSH can be deployed as a single POSIX script with no configure/build step.
+Deploying it this way leave you without any man page or shell completion functions.
+This variant is also dependent or you `$PATH` to have proper versions of dependencies such as `git`.
+If your user space has different tools by default than your system beware!
+
+The standalone variant can be downloaded from under any entry in [releases](https://github.com/RichiH/vcsh/releases).
+
+This method is suited for installation to a user space where you don't have control over the system packages, e.g.:
+
+```console
+$ mkdir ~/bin
+$ curl -fsLS https://github.com/RichiH/vcsh/releases/latest/download/vcsh-standalone.sh -O ~/bin/vcsh
+$ chmod 755 ~/bin/vcsh
+```
+
+It could also be used to directly bootstrap a dotfiles repository something like this:
+
+```console
+$ sh <(curl -fsLS https://github.com/RichiH/vcsh/releases/latest/download/vcsh-standalone.sh) clone <path_to_your_dotfiles_repo> dotfiles
+```
+
+Note that we strongly encourage using a tagged version that you've tested to work for you instead of the *latest* keyword.
 
 [1]: http://rtomayko.github.io/ronn/

--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -127,12 +127,12 @@ This will install to `~/bin/vcsh`; add `~/bin` to your path to use.
 
 # Standalone Script
 
-A special variant of VCSH can be deployed as a single POSIX script with no configure/build step.
-Deploying it this way leave you without any man page or shell completion functions.
-This variant is also dependent or you `$PATH` to have proper versions of dependencies such as `git`.
+A special variant of VCSH can be deployed as a single POSIX shell script with no configure/build step.
+Deploying it this way leaves you without any man page or shell completion functions (or possibly with mismatched resources installed by your package manager for a different vcsh version).
+This variant is also dependent or your `$PATH` to have proper versions of dependencies such as `git`.
 If your user space has different tools by default than your system beware!
 
-The standalone variant can be downloaded from under any entry in [releases](https://github.com/RichiH/vcsh/releases).
+The standalone variant can be downloaded from any recent entry in [releases](https://github.com/RichiH/vcsh/releases).
 
 This method is suited for installation to a user space where you don't have control over the system packages, e.g.:
 
@@ -142,12 +142,12 @@ $ curl -fsLS https://github.com/RichiH/vcsh/releases/latest/download/vcsh-standa
 $ chmod 755 ~/bin/vcsh
 ```
 
-It could also be used to directly bootstrap a dotfiles repository something like this:
+It could also be used to directly bootstrap a dotfiles repository with something like this:
 
 ```console
 $ sh <(curl -fsLS https://github.com/RichiH/vcsh/releases/latest/download/vcsh-standalone.sh) clone <path_to_your_dotfiles_repo> dotfiles
 ```
 
-Note that we strongly encourage using a tagged version that you've tested to work for you instead of the *latest* keyword.
+While we are enabling cURL-based workflows on purpose, we still encourage you to avoid them where reasonably possible. If you do use it, please consider using a tagged version that you've tested to work for you instead of the "latest" keyword.
 
 [1]: http://rtomayko.github.io/ronn/

--- a/vcsh.in
+++ b/vcsh.in
@@ -19,7 +19,7 @@
 # If '.r<N>-g<SHA>' is appended to the version, you are seeing an unreleased
 # version of vcsh; the main branch is supposed to be clean at all times
 # so you can most likely just use it nonetheless
-VCSH_VERSION='@VERSION@'; export VCSH_VERSION
+VCSH_VERSION='@VERSION@@EDITION@'; export VCSH_VERSION
 VCSH_SELF="@TRANSFORMED_PACKAGE_NAME@"; export VCSH_SELF
 
 # Ensure all files created are accessible only to the current user.

--- a/vcsh.in
+++ b/vcsh.in
@@ -19,7 +19,7 @@
 # If '.r<N>-g<SHA>' is appended to the version, you are seeing an unreleased
 # version of vcsh; the main branch is supposed to be clean at all times
 # so you can most likely just use it nonetheless
-VCSH_VERSION='@VERSION@@EDITION@'; export VCSH_VERSION
+VCSH_VERSION='@VERSION@@DEPLOYMENT@'; export VCSH_VERSION
 VCSH_SELF="@TRANSFORMED_PACKAGE_NAME@"; export VCSH_SELF
 
 # Ensure all files created are accessible only to the current user.

--- a/vcsh.in
+++ b/vcsh.in
@@ -17,10 +17,11 @@
 
 
 # If '.r<N>-g<SHA>' is appended to the version, you are seeing an unreleased
-# version of vcsh; the main branch is supposed to be clean at all times
-# so you can most likely just use it nonetheless
+# version built from the main branch HEAD. If "-standalone" is appended you are
+# using a version built explicitly for portability as a standalone script
+# rather than being installed to a specific system.
 VCSH_VERSION='@VERSION@@DEPLOYMENT@'; export VCSH_VERSION
-VCSH_SELF="@TRANSFORMED_PACKAGE_NAME@"; export VCSH_SELF
+VCSH_SELF='@TRANSFORMED_PACKAGE_NAME@'; export VCSH_SELF
 
 # Ensure all files created are accessible only to the current user.
 umask 0077


### PR DESCRIPTION
Fixes #202.

I debated whether to call this special build "bootstrap" or "standalone". In the end "standalone" made more sense to me, but if anybody has a stronger opinion mine is pretty weak.

The idea is to just use the existing build system but tweak it to:

* not build any of the extras like man pages or completions
* not actually detect anything about the host environment, have it just assume `$PATH` will work at runtime
* add a `-standalone` segment to the version string so bug reports are easier to identify
* post the resulting script as an artifact on all CI jobs
* attach the resulting script "bare" (with no version info in the filename) to releases so that it can be downloaded using a oneliner, e.g. `curl -fsLOJS https://github.com/RichiH/vcsh/releases/latest/download/vcsh-standalone.sh`