### PR TITLE
Distribute test fixtures in source distribution

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -18,6 +18,7 @@ endif
 bin_SCRIPTS = vcsh
 
 EXTRA_DIST  = completions/vcsh.bash completions/vcsh.zsh build-aux/git-version-gen build-aux/ax_prog_perl_modules.m4
+EXTRA_DIST += t/000-tear-env.t t/001-setup-env.t t/100-init.t t/300-add.t t/950-delete.t t/999-tear-env.t
 
 BUILT_SOURCES = .version
 CLEANFILES = $(BUILT_SOURCES) .version-prev $(dist_man_MANS) $(bin_SCRIPTS)


### PR DESCRIPTION
That *running* tests is now an optional part of the configure and build cycle is totally expected. Not having the sources necessary to run tests if you want to was an oversight.

I've been testing mostly from `git clone` environments. Testing downstream packaging built from the tarball brought this to my attention. The sources were fine if you just built and installed them, but `make test` didn't work from a source distribution tarball.