### PR TITLE
Update CI tooling to match upstream change

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,8 +43,6 @@ jobs:
           files: |
             vcsh-${{ env.VERSION }}.zip
             vcsh-${{ env.VERSION }}.tar.xz
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
 
   deploy-standalone:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This is a minor tweak to remove code cruft no longer needed since my [PR has been accepted upstream](https://github.com/softprops/action-gh-release/pull/83). Since GitHub passes the data anyway it is no longer necessary to explicit pass a token. This has been tested on my fork in [this CI run](https://github.com/alerque/vcsh/actions/runs/1070790599).
