### PR TITLE
Only require ronn when building from Git, not from source dist

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -13,7 +13,7 @@ samplehooksdir = $(docdir)/sample_hooks
 dist_samplehooks_DATA = doc/sample_hooks/post-init-add-origin doc/sample_hooks/post-init-setup-mr doc/sample_hooks/post-merge-unclobber doc/sample_hooks/pre-merge-unclobber
 dist_license_DATA = LICENSE CONTRIBUTORS
 if ENABLE_MAN_PAGE
-dist_man_MANS = vcsh.1
+dist_man_MANS = doc/vcsh.1
 endif
 bin_SCRIPTS = vcsh
 
@@ -35,7 +35,7 @@ nodist_zshcompletion_DATA = completions/_$(TRANSFORMED_PACKAGE_NAME)
 CLEANFILES += $(nodist_zshcompletion_DATA)
 endif
 
-vcsh.1: doc/vcsh.1.ronn
+doc/vcsh.1: doc/vcsh.1.ronn
 	$(RONN) < $< > $@
 
 completions/$(TRANSFORMED_PACKAGE_NAME): completions/vcsh.bash

--- a/Makefile.am
+++ b/Makefile.am
@@ -35,8 +35,10 @@ nodist_zshcompletion_DATA = completions/_$(TRANSFORMED_PACKAGE_NAME)
 CLEANFILES += $(nodist_zshcompletion_DATA)
 endif
 
+if !IS_SDIST
 doc/vcsh.1: doc/vcsh.1.ronn
 	$(RONN) < $< > $@
+endif
 
 completions/$(TRANSFORMED_PACKAGE_NAME): completions/vcsh.bash
 	mkdir -p $(dir $@)

--- a/changelog
+++ b/changelog
@@ -1,3 +1,7 @@
+unreleased
+
+	* Stop requiring `ronn` when building from source tarball
+
 2021-08-20  Caleb Maclennan <caleb@alerque.com>
 
 	* Release 2.0.0

--- a/configure.ac
+++ b/configure.ac
@@ -68,9 +68,10 @@ AC_ARG_ENABLE([tests],
                              [Configure tooling to run tests @<:@default=TESTDEF@:>@]),
               [],
               [enable_tests=TESTDEF])
-AM_CONDITIONAL([ENABLE_TESTS],[test x"$enable_tests" != x"no"])
+AM_CONDITIONAL([ENABLE_TESTS],
+               [test x"$enable_tests" != x"no"])
 
-AS_IF([test x"$enable_tests" != x"no"], [
+AM_COND_IF([ENABLE_TESTS], [
        AX_PROGVAR([prove])
        AX_PROG_PERL_MODULES(Shell::Command, [],
                             AC_MSG_ERROR(Perl module required for testing not found))
@@ -83,28 +84,26 @@ AC_ARG_WITH([bash-completion-dir],
                            [Install bash auto-completion definitions to a directory. @<:@default=yes@:>@]),
             [],
             [with_bash_completion_dir=yes])
-AS_IF([test x"$with_bash_completion_dir" = x"yes"],
+AM_CONDITIONAL([ENABLE_BASH_COMPLETION],
+               [test x"$with_bash_completion_dir" != x"no"])
+AM_COND_IF([ENABLE_BASH_COMPLETION],
       [PKG_CHECK_MODULES([BASH_COMPLETION], [bash-completion >= 2.0],
                          [BASH_COMPLETION_DIR="$(pkg-config --define-variable=datadir=$datadir --variable=completionsdir bash-completion)"],
                          [BASH_COMPLETION_DIR="$datadir/bash-completion/completions"])],
       [BASH_COMPLETION_DIR="$with_bash_completion_dir"])
 AC_SUBST([BASH_COMPLETION_DIR])
-AM_CONDITIONAL([ENABLE_BASH_COMPLETION],
-               [test x"$with_bash_completion_dir" != x"no"])
 
 AC_ARG_WITH([zsh-completion-dir],
             AS_HELP_STRING([--with-zsh-completion-dir[=PATH]],
                            [Install zsh auto-completion definitions to a directory. @<:@default=yes@:>@]),
             [],
             [with_zsh_completion_dir=yes])
-if test x"$with_zsh_completion_dir" = x"yes"; then
-    ZSH_COMPLETION_DIR="$datadir/zsh/site-functions"
-else
-    ZSH_COMPLETION_DIR="$with_zsh_completion_dir"
-fi
-AC_SUBST([ZSH_COMPLETION_DIR])
 AM_CONDITIONAL([ENABLE_ZSH_COMPLETION],
                [test x"$with_zsh_completion_dir" != x"no"])
+AM_COND_IF([ENABLE_ZSH_COMPLETION],
+           [ZSH_COMPLETION_DIR="$datadir/zsh/site-functions"],
+           [ZSH_COMPLETION_DIR="$with_zsh_completion_dir"])
+AC_SUBST([ZSH_COMPLETION_DIR])
 
 TRANSFORMED_PACKAGE_NAME="$(printf "$PACKAGE_NAME" | $SED -e "${program_transform_name//\$\$/\$}")"
 AC_SUBST([TRANSFORMED_PACKAGE_NAME])

--- a/configure.ac
+++ b/configure.ac
@@ -5,6 +5,9 @@ AM_INIT_AUTOMAKE([foreign tar-pax dist-xz dist-zip no-dist-gzip color-tests])
 AM_SILENT_RULES([yes])
 AC_CONFIG_MACRO_DIR([build-aux])
 
+AM_CONDITIONAL([IS_SDIST],
+               [test -e .tarball-version])
+
 AC_DEFUN([AX_PROGVAR], [
           test -n "$m4_toupper($1)" || { AC_PATH_PROG(m4_toupper($1), m4_default($2,$1)) }
           test -n "$m4_toupper($1)" || AC_MSG_ERROR([m4_default($2,$1) is required])
@@ -48,15 +51,18 @@ AC_ARG_WITH([man-page],
                            [Generate man page @<:@default=yes@:>@]),
             [],
             [with_man_page=yes])
-if test x"$with_man_page" = x"yes" -a ! -f .tarball-version; then
-    AX_PROGVAR([ronn])
-fi
 AM_CONDITIONAL([ENABLE_MAN_PAGE],
                [test x"$with_man_page" != x"no"])
 
-AS_IF([test -e .tarball-version],
-      m4_define([TESTDEF], [yes]),
-      m4_define([TESTDEF], [no]))
+AM_COND_IF([IS_SDIST],
+           [],
+           [AM_COND_IF([ENABLE_MAN_PAGE],
+                       [AX_PROGVAR([ronn])])
+])
+
+AM_COND_IF([IS_SDIST],
+           m4_define([TESTDEF], [yes]),
+           m4_define([TESTDEF], [no]))
 AC_ARG_ENABLE([tests],
               AS_HELP_STRING([--disable-tests],
                              [Configure tooling to run tests @<:@default=TESTDEF@:>@]),

--- a/configure.ac
+++ b/configure.ac
@@ -48,7 +48,7 @@ AC_ARG_WITH([man-page],
                            [Generate man page @<:@default=yes@:>@]),
             [],
             [with_man_page=yes])
-if test x"$with_man_page" = x"yes"; then
+if test x"$with_man_page" = x"yes" -a ! -f .tarball-version; then
     AX_PROGVAR([ronn])
 fi
 AM_CONDITIONAL([ENABLE_MAN_PAGE],


### PR DESCRIPTION
Fixes #313

We were 95% of the way there on this anyway. The source dist tarball already does have the prebuilt man page ready to use, only the `./configure` script was being told it needed `ronn` to continue. This just detects when being run from the tarball based on another artifact only found in the tarball and not in the Git sources and based on that decides if it can skip that dependency check.