### PR TITLE
Revert change to .gitignore.d behavior in #196

### DIFF
--- a/vcsh.in
+++ b/vcsh.in
@@ -569,16 +569,11 @@ write_gitignore() {
 	OLDIFS=$IFS
 	IFS=$(printf '\n\t')
 	gitignores=$(for file in $(@GIT@ ls-files); do
-		if [ "$GIT_VERSION_MAJOR" -ge 2 ] \
-				&& [ "$GIT_VERSION_MINOR" -ge 7 ]; then
-			echo "$file";
-		else
-			while true; do
-				echo "$file"; new=${file%/*}
-				[ x"$file" = x"$new" ] && break
-				file=$new
-			done;
-		fi
+		while true; do
+			echo "$file"; new=${file%/*}
+			[ x"$file" = x"$new" ] && break
+			file=$new
+		done;
 	done | sort -u)
 
 	# Contrary to GNU mktemp, mktemp on BSD/OSX requires a template for temp files


### PR DESCRIPTION
Fixes #333.

In git 2.7.0, new git behavior changed gitignore to no longer require un-ignoring every parent directory above an un-ignored file. vcsh updated its logic around this in PR #196 (RichiH/vcsh@e4f4ecf). Unfortunately, git's change was reverted before 2.8.0-rc4 (git/git@5cee349).

This change therefore reverts the logic change in #196 causing `vcsh write-gitignore` to once again emit parent directories into generated `.gitignore.d/<repo>` files.

See #333 for the gory details.