### PR TITLE
Add suport for adding main commands, plugins

### DIFF
--- a/doc/vcsh.1.ronn.in
+++ b/doc/vcsh.1.ronn.in
@@ -300,6 +300,19 @@ may even lose data.
 
 You have been warned.
 
+## PLUGIN SYSTEM
+
+`@TRANSFORMED_PACKAGE_NAME@` also provides a plugin system. Similar to overlays, the recommended
+locations are <$XDG_CONFIG_HOME/vcsh/plugins-available> and
+<$XDG_CONFIG_HOME/vcsh/plugins-enabled>.
+
+Plugins follow the same rules as hooks and you are free to overwrite any
+and all functions.
+
+The plugin file name will be the added `@TRANSFORMED_PACKAGE_NAME@` command.
+The file should contain a function with same name as the file and
+optionally a help function. The help is stubbed if not implemented.
+
 ## DETAILED HOWTO AND FURTHER READING
 
 Manpages are often short and sometimes useless to glean best practices from.

--- a/vcsh.in
+++ b/vcsh.in
@@ -87,6 +87,7 @@ fi
 : "${VCSH_REPO_D:="$XDG_CONFIG_HOME/vcsh/repo.d"}"; export VCSH_REPO_D
 : "${VCSH_HOOK_D:="$XDG_CONFIG_HOME/vcsh/hooks-enabled"}"; export VCSH_HOOK_D
 : "${VCSH_OVERLAY_D:="$XDG_CONFIG_HOME/vcsh/overlays-enabled"}"; export VCSH_OVERLAY_D
+: "${VCSH_PLUGIN_D:="$XDG_CONFIG_HOME/vcsh/plugins-enabled"}"; export VCSH_PLUGIN_D
 : "${VCSH_BASE:="$HOME"}"; export VCSH_BASE
 : "${VCSH_GITIGNORE:=exact}"; export VCSH_GITIGNORE
 : "${VCSH_GITATTRIBUTES:=none}"; export VCSH_GITATTRIBUTES
@@ -145,6 +146,17 @@ help() {
 
    <repo> <git command> Shortcut to run git commands directly
    <repo>               Shortcut to enter repository" >&2
+	for plugin in "$VCSH_PLUGIN_D/"*; do
+		[ -r "$plugin" ] || continue
+		(
+			help() {
+				printf "   %-21s%s\n" "$(basename "$plugin")" "Plugin help not implemented"
+			}
+			# shellcheck source=/dev/null
+			. "$plugin"
+			help
+		) >&2
+	done
 }
 # editorconfig-checker-enable
 
@@ -699,6 +711,11 @@ elif [ x"$VCSH_COMMAND" = x'status' ]; then
 		shift
 	fi
 	VCSH_REPO_NAME=$2; export VCSH_REPO_NAME
+elif [ -n "$VCSH_COMMAND" ] &&
+	[ -r "$VCSH_PLUGIN_D/$VCSH_COMMAND" ]; then
+	info "sourcing plugin '$VCSH_PLUGIN_D/$VCSH_COMMAND'"
+	# shellcheck source=/dev/null
+	. "$VCSH_PLUGIN_D/$VCSH_COMMAND"
 elif [ -n "$2" ]; then
 	VCSH_COMMAND='run'; export VCSH_COMMAND
 	VCSH_REPO_NAME=$1; export VCSH_REPO_NAME


### PR DESCRIPTION
vcsh is incredibly extendable and flexible however there is no possibility to add new commands. This is were plugins come into play. By adding plugins to $XDG_CONFIG_HOME/vcsh/plugins-enabled new commands become available.
The plugin file name becomes the new command, the file must contain a function with the same name as the file, this is the entry point. A help function can also be added to get append the plugin help text to the main help text, if help is omitted a default help message is added.